### PR TITLE
Send/receive messages with Chaise

### DIFF
--- a/js/osd.annotorious.js
+++ b/js/osd.annotorious.js
@@ -1,3 +1,4 @@
+// An event listener to capture messages from Chaise
 window.addEventListener('message', function(event) {
     if (event.origin === window.location.origin) {
         var messageType = event.data.messageType;
@@ -173,9 +174,9 @@ function annoLog(item, eventType) {
 /* if data has url embedded in there. need to escape with
 encoded = encodeURIComponent( parm )
 */
-   if( debug ) {
-      printDebug(json);
-   }
+   // if( debug ) {
+   //    printDebug(json);
+   // }
    return json;
 }
 

--- a/js/osd.annotorious.js
+++ b/js/osd.annotorious.js
@@ -33,6 +33,26 @@ window.addEventListener('message', function(event) {
                 });
                 readAll(annotationsToLoad);
                 break;
+            case 'highlightAnnotation':
+                var annotationObj = {
+                    "src": "dzi://openseadragon/something",
+                    "text": data.comments,
+                    "shapes": [
+                        {
+                            "type": "rect",
+                            "geometry": {
+                                "x": data.coords[0],
+                                "y": data.coords[1],
+                                "width": data.coords[2],
+                                "height": data.coords[3]
+                            },
+                            "style": {}
+                        }
+                    ],
+                    "context": data.context_uri
+                };
+                centerAnnoByHash(getHash(annotationObj));
+                break;
             default:
                 console.log('Invalid message type. No action performed.');
         }

--- a/js/osd.annotorious.js
+++ b/js/osd.annotorious.js
@@ -6,7 +6,6 @@ window.addEventListener('message', function(event) {
             case 'annotationsList':
                 var annotationsToLoad = {"annoList":[]};
                 data.map(function formatAnnotationObj(annotation) {
-                    annotation = annotation.data;
                     var annotationObj = {
                         "type": "openseadragon_dzi",
                         "id": null,

--- a/js/osd.annotorious.js
+++ b/js/osd.annotorious.js
@@ -57,7 +57,7 @@ function annoExist(item) {
 function annoRetrieve(i) {
   var p=myAnno.getAnnotations();
   var len = p.length;
-  if (i>=0 && i <len) 
+  if (i>=0 && i <len)
     return p[i];
   return null;
 }
@@ -89,6 +89,7 @@ function annoSetup(_anno,_viewer) {
   _anno.addHandler("onAnnotationCreated", function(target) {
     var item=target;
     var json=annoLog(item,CREATE_EVENT_TYPE);
+    window.top.postMessage(json, 'http://dev.rebuildingakidney.org');
     updateAnnotationList();
   });
   _anno.addHandler("onAnnotationRemoved", function(target) {
@@ -144,7 +145,7 @@ function annotate() {
 }
 
 // only shape supported is rect, this is to create an annotation
-// item by hand 
+// item by hand
 function annoMakeAnno(_src,_context,_text,_x,_y,_width,_height)
 {
   var myAnnotation = {
@@ -174,7 +175,7 @@ function updateAnnotationList() {
     _addAnnoOption(getHash(annotations[i]));
     var formattedAnnotation =
       '<a href="#"><div class="panel panel-default">' +
-        '<div class="panel-body" id=' + getHash(annotations[i]) +' ' + 
+        '<div class="panel-body" id=' + getHash(annotations[i]) +' ' +
                     'onclick=centerAnnoByHash('+ getHash(annotations[i]) +')'+
 '>' +
                     annotations[i].text +
@@ -186,7 +187,7 @@ function updateAnnotationList() {
 
 function _clearAnnoOptions() {
   var alist = document.getElementById('anno-list');
-  if(alist == null) 
+  if(alist == null)
     return;
   while (alist.length > 0) {
       alist.remove(alist.length - 1);
@@ -282,7 +283,7 @@ function centerAnnoByHash(i)
      var my=(h/10);
      var ctxt=item.context;
      var src=item.src;
-    
+
      goPositionByBounds(x-mx,y-my,w+(2*mx),h+(2*my));
      annoHighlightAnnotation(item);
 // add a tiny annotation here..
@@ -332,4 +333,3 @@ function makeDummy() {
     0.3020050125313283
   );
 }
-

--- a/js/osd.viewer_multi.js
+++ b/js/osd.viewer_multi.js
@@ -146,7 +146,7 @@ jQuery(document).ready(function() {
 // when propertyList matches with total cnt..
        if( propertyList.length == myViewer.world.getItemCount()) {
          showFilters=true;
-         _addFilters(); 
+         _addFilters();
        }
      });
    }
@@ -271,8 +271,8 @@ function updateTitle(_X,_Y,_Z) {
             if( isFirst ) {
                isFirst=false;
                history.replaceState({}, 'Title', newTitle)
-               } else { 
-                 history.pushState(stateObj, 'Title', newTitle)
+               } else {
+                   history.replaceState(stateObj, 'Title', newTitle)
             }
             return 1;
             } else {

--- a/mview.html
+++ b/mview.html
@@ -44,7 +44,7 @@
       #viewer {
           position: fixed;
           left: 0;
-          width: 80%;
+          width: 100%;
           height: 100vh;
           margin-bottom: 0;
       }

--- a/mview.html
+++ b/mview.html
@@ -50,6 +50,7 @@
       }
 
       #annotations {
+          display: none;
           color: black;
           position: fixed;
           right: 0;
@@ -65,6 +66,7 @@
       }
 
       #control {
+          display: none;
           position: fixed;
           right: 0;
           width: 20%;


### PR DESCRIPTION
This pull request allows the OpenSeadragon + Annotorious viewer to communicate with the Chaise "Viewer" app via [window.postMessage()](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage). 

It adds functionality that allows users to create and select annotations on the Chaise side and see corresponding changes (creation and highlighting of annotations) inside OpenSeadragon/Annotorious.