### PR TITLE
Solved issue #22

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -69,7 +69,8 @@ var _config = {
           }
         },
         constants: {
-          unknownAnnotation: 'UNKNOWN',
+          UNKNOWN_ANNNOTATION: 'UNKNOWN',
+          STYLE_ATTRIBUTE_LIST: ['alignment-baseline', 'baseline-shift', 'clip', 'clip-path', 'clip-rule', 'color', 'color-interpolation', 'color-interpolation-filters', 'color-profile', 'color-rendering', 'cursor', 'direction', 'display', 'dominant-baseline', 'enable-background', 'fill', 'fill-opacity', 'fill-rule', 'filter', 'flood-color', 'flood-opacity', 'font-family', 'font-size', 'font-size-adjust', 'font-stretch', 'font-style', 'font-variant', 'font-weight', 'glyph-orientation-horizontal', 'glyph-orientation-vertical', 'image-rendering', 'kerning', 'letter-spacing', 'lighting-color', 'marker-end', 'marker-mid', 'marker-start', 'mask', 'opacity', 'overflow', 'pointer-events', 'shape-rendering', 'stop-color', 'stop-opacity', 'stroke', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'text-anchor', 'text-decoration', 'text-rendering', 'transform', 'transform-origin', 'unicode-bidi', 'vector-effect', 'visibility', 'word-spacing', 'writing-mode'],
         },
     },
 };

--- a/js/config.js
+++ b/js/config.js
@@ -67,6 +67,9 @@ var _config = {
               fontSize: "small",
               barThickness: 3
           }
-        }
+        },
+        constants: {
+          unknownAnnotation: 'UNKNOWN',
+        },
     },
 };

--- a/js/viewer/annotation/annotation-svg.js
+++ b/js/viewer/annotation/annotation-svg.js
@@ -165,15 +165,11 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
             .remove();
     }
 
-    // get viewbox of the svg 
-    this.getViewBox = function () {
-        return (this.viewBox) ? this.viewBox : [0, 0, this.imgWidth, this.imgHeight];
-    }
-
     this.parseSVGFile = function(svgFile){
 
         if(!svgFile){ return; }
 
+        // to set the viewBox attribute of the svg, first it is checked of the attributes exsists in the svg file itself or not. If it does exsist then that value is assigned, otherwise we look for the height and width attribute in the svg file and assign [0, 0, height, width]. If none of these are present we display an error in the console.
         if (svgFile.getAttribute("viewBox")) {
             this.viewBox = svgFile.getAttribute("viewBox").split(" ").map(
                 function (num) {
@@ -259,12 +255,11 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
     /**
      * Checks all the style attributes in the node and returns the in the form of a string
      * @param {object} node
-     * @return {styleAttributeString}
+     * @return {string} the returned value is a string that is similar to the 'style' attribute of a node i.e. style in a svg node.
      */
     this.getStyleAttributes = function (node) {
 
-        console.log('styleProperties', node);
-        styleAttributeList = ['alignment-baseline', 'baseline-shift', 'clip', 'clip-path', 'clip-rule', 'color', 'color-interpolation', 'color-interpolation-filters', 'color-profile', 'color-rendering', 'cursor', 'direction', 'display', 'dominant-baseline', 'enable-background', 'fill', 'fill-opacity', 'fill-rule', 'filter', 'flood-color', 'flood-opacity', 'font-family', 'font-size', 'font-size-adjust', 'font-stretch', 'font-style', 'font-variant', 'font-weight', 'glyph-orientation-horizontal', 'glyph-orientation-vertical', 'image-rendering', 'kerning', 'letter-spacing', 'lighting-color', 'marker-end', 'marker-mid', 'marker-start', 'mask', 'opacity', 'overflow', 'pointer-events', 'shape-rendering', 'stop-color', 'stop-opacity', 'stroke', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'text-anchor', 'text-decoration', 'text-rendering', 'transform', 'transform-origin', 'unicode-bidi', 'vector-effect', 'visibility', 'word-spacing', 'writing-mode'];
+        styleAttributeList = parent.all_config.constants.STYLE_ATTRIBUTE_LIST;
 
         styleAttributeString = '';
 
@@ -274,14 +269,13 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
                 styleAttributeString += styleAttributeList[i] + ':' + value + ';';
             }
         }
-
         return styleAttributeString;
     }
 
     /**
      * Will return an object of the style string
      * @param {string} styleString
-     * @return {styleObject}
+     * @return {object} the returned object is a key (eg style property like 'font-size') and value (eg '20px') pair
      */
     this.styleStringToObject = function (styleString) {
         styleString = styleString.replace(/\s/g, '');
@@ -294,9 +288,11 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
         styleString = styleString.split(';');
 
         for (i = 0; i < styleString.length; i++) {
-            var property = styleString[i].split(':')[0];
-            var value = styleString[i].split(':')[1];
-            styleObject[property] = value;
+            var property, value;
+            [property, value] = styleString[i].split(':')
+            if (value) {
+                styleObject[property] = value;
+            }
         }
 
         return styleObject;
@@ -305,7 +301,7 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
     /**
      * Will return a string of the style object, opposite of styleStringToObject function
      * @param {object} styleObject
-     * @return {styleString}
+     * @return {string} 
      */
     this.styleObjectToString = function (styleObject) {
         var styleString = '';
@@ -321,10 +317,10 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
     }
 
     /**
-     * Take the properties from the parent style and appends them to the child node
+     * Take the properties from the parent style and appends them to the child node if they are missing from the child.
      * @param {string} parentStyle
      * @param {string} selfStyle
-     * @return {selfStyle}
+     * @return {string}
      */
     this.mergeWithParentStyle = function (parentStyle, selfStyle) {
 
@@ -346,13 +342,13 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
     }
     
     /**
-     * Take the properties from the parent style and appends them to the child node
+     * Returns the node ID, which can is defined by the following logic: if the node has an ID return that else check for the name attribute in the node. If name is not present then check if the parent of that node has an ID, if yes then return that. In case non of these are present, then return a constant.
      * @param {object} node
      * @param {object} parentNode
-     * @return {nodeID}
+     * @return {string}
      */
     this.getNodeID = function(node, parentNode) {
-        return node.getAttribute("id") || node.getAttribute("name") || parentNode.getAttribute("id") || parent.all_config.constants.unknownAnnotation;
+        return node.getAttribute("id") || node.getAttribute("name") || parentNode.getAttribute("id") || parent.all_config.constants.UNKNOWN_ANNNOTATION;
     }
 
 

--- a/js/viewer/annotation/base.js
+++ b/js/viewer/annotation/base.js
@@ -120,6 +120,7 @@ Base.prototype.setAttributesBySVG = function(elem){
         if(value != null){
             switch(attr){
                 case "style":
+                    value = value.replace(/\s/g, '');
                     styleArr = value.split(";");
                     for(var i = 0; i < styleArr.length; i++){
                         var attrName = styleArr[i].split(":")[0];

--- a/test/svg/README.md
+++ b/test/svg/README.md
@@ -17,3 +17,9 @@ This file contains 4 node, one for each of the possible case to assign an <ID> t
 	2. the node has a Name, but not an ID
 	3. The parent of the node has an ID, but the node itself has neither ID nor Name
 	4. None of the above
+
+- threeViewboxAttributes.svg
+This svg contains a viewbox having 3 values only, instead of the normal four whcih are required. Since the viewbox is not according to the SVG standards, this files will not be displayed and give a <console.log()> error.
+
+- heightWidthNoViewbox.svg
+This file does not contain a viewBox attribute, but has a height and width. The height and width are used to create a viewbox in this case and the file is displayed according the those values.

--- a/test/svg/README.md
+++ b/test/svg/README.md
@@ -1,0 +1,12 @@
+# SVG File description
+
+Make sure that the viewbox attribute of the file is set properly so that it aligns with the image that it is being tested on.
+
+- styleWithSpace.svg
+This svg file contains the style tag having spaces. Place the file path in the URL to test if it is being handled properly or not.
+
+- cascadingProperties.svg
+This svg file contains a group <g> in which style is defined. The group contains 2 <circle> inside it. The first circle inherits the 'opacity' property from the parent, i.e. the group, while the second circle which already contains the 'opacity' property does not get affected.
+
+- noViewbox.svg
+This file contains an SVG which does not have a viewBox. When such an svg is used, it won't be displayed and for now will give a <console.log()> error.

--- a/test/svg/README.md
+++ b/test/svg/README.md
@@ -10,3 +10,10 @@ This svg file contains a group <g> in which style is defined. The group contains
 
 - noViewbox.svg
 This file contains an SVG which does not have a viewBox. When such an svg is used, it won't be displayed and for now will give a <console.log()> error.
+
+- getNodeIdVariations.svg
+This file contains 4 node, one for each of the possible case to assign an <ID> to the node in the SVG. The 4 cases are:
+	1. The node has an ID
+	2. the node has a Name, but not an ID
+	3. The parent of the node has an ID, but the node itself has neither ID nor Name
+	4. None of the above

--- a/test/svg/cascadingProperties.svg
+++ b/test/svg/cascadingProperties.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17451 18493" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<style>
+		circle {
+			stroke: maroon;
+			stroke-width: 20px;
+		}
+	</style>
+	<g style="opacity:0.3">
+		<g style="fill: red">
+			<circle id="EHDAA2:0028494,ureteric trunk" cx="8000" cy="3000" r="1000" style="stroke-width:1px;stroke:maroon; fill:none; stroke-linecap:round; vector-effect:non-scaling-stroke"/>
+			<circle id="EHDAA2:0028494,ureteric trunk" cx="10000" cy="3000" r="1000" style="stroke-width:1px;stroke:maroon; fill:none; stroke-linecap:round; vector-effect:non-scaling-stroke; opacity:1"/>
+		</g>
+	</g>
+</svg>

--- a/test/svg/getNodeIdVariations.svg
+++ b/test/svg/getNodeIdVariations.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17451 18493" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<g style="opacity:0.3">
+		<g style="fill: red">\
+			<circle name="EHDAA2:0028494,ureteric trunk-has-name" cx="10000" cy="3000" r="1000" style="stroke-width:1px;stroke:maroon; fill:none; stroke-linecap:round; vector-effect:non-scaling-stroke; opacity:1"/>
+		</g>
+	</g>
+	<g style="opacity:0.3">
+		<g style="fill: red">
+			<circle id="EHDAA2:0028494,ureteric trunk-has-id" cx="8000" cy="3000" r="1000" style="stroke-width:1px;stroke:maroon; fill:none; stroke-linecap:round; vector-effect:non-scaling-stroke"/>
+		</g>
+	</g>
+	<g>
+		<g style="fill: green" id="EHDAA2:0028494,ureteric trunk-has-parent-id">
+			<circle cx="10000" cy="5000" r="1000" style="stroke-width:1px;stroke:green; fill:none; stroke-linecap:round; vector-effect:non-scaling-stroke"/>
+		</g>
+	</g>
+	<g>
+		<g style="fill: yellow">
+			<circle cx="8000" cy="5000" r="1000" style="stroke-width:1px;stroke:yellow; fill:none; stroke-linecap:round; vector-effect:non-scaling-stroke"/>
+		</g>
+	</g>
+</svg>

--- a/test/svg/heightWidthNoViewbox.svg
+++ b/test/svg/heightWidthNoViewbox.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="17451" width="18493" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<g style="opacity:0.3">
+		<g style="fill: red">
+			<circle id="EHDAA2:0028494,ureteric trunk" cx="8000" cy="3000" r="1000" style="stroke-width:1px;stroke:maroon; fill:none; stroke-linecap:round; vector-effect:non-scaling-stroke"/>
+			<circle id="EHDAA2:0028494,ureteric trunk" cx="10000" cy="3000" r="1000" style="stroke-width:1px;stroke:maroon; fill:none; stroke-linecap:round; vector-effect:non-scaling-stroke; opacity:1"/>
+		</g>
+	</g>
+</svg>

--- a/test/svg/noViewbox.svg
+++ b/test/svg/noViewbox.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg"  xmlns:xlink="http://www.w3.org/1999/xlink">
+	<style>
+		circle {
+			stroke: maroon;
+			stroke-width: 20px;
+		}
+	</style>
+	<g style="fill: black">
+		<g style="fill: red">
+			<circle id="EHDAA2:0028494,ureteric trunk" cx="8000" cy="3000" r="1000" style="stroke-width:1px; stroke:maroon; fill:none; stroke-linecap:round; vector-effect:non-scaling-stroke"/>
+		</g>
+	</g>
+</svg>

--- a/test/svg/styleWithSpace.svg
+++ b/test/svg/styleWithSpace.svg
@@ -1,0 +1,7 @@
+<svg viewBox="20546 0 3831 4059" xmlns="http://www.w3.org/2000/svg"  xmlns:xlink="http://www.w3.org/1999/xlink">
+	<g style="fill: black">
+		<g style="fill: red">
+			<circle id="EHDAA2:0028494,ureteric trunk" cx="21956.3" cy="1407.86" r="300" style="stroke-width:1px; stroke:maroon; fill:none; stroke-linecap:round; vector-effect:non-scaling-stroke"/>
+		</g>
+	</g>
+</svg>

--- a/test/svg/threeViewboxAttributes.svg
+++ b/test/svg/threeViewboxAttributes.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17451" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<g style="opacity:0.3">
+		<g style="fill: red">
+			<circle id="EHDAA2:0028494,ureteric trunk" cx="8000" cy="3000" r="1000" style="stroke-width:1px;stroke:maroon; fill:none; stroke-linecap:round; vector-effect:non-scaling-stroke"/>
+			<circle id="EHDAA2:0028494,ureteric trunk" cx="10000" cy="3000" r="1000" style="stroke-width:1px;stroke:maroon; fill:none; stroke-linecap:round; vector-effect:non-scaling-stroke; opacity:1"/>
+		</g>
+	</g>
+</svg>


### PR DESCRIPTION
Solved the problems that were mentioned in the issue.

Added code for merging parent node attributes like 'color', 'height' etc, which can also be part of the style attribute, to the child node for displaying the annotation. The attributes which need to be passed down to the child need to be discussed.

As discussed, when a svg file does not have a viewbox attribute, a console.log error is displayed. This error can be handled at a later stage. 