### PR TITLE
add logic for default color in annotation toolbar

### DIFF
--- a/js/toolbar/annotation-tool.js
+++ b/js/toolbar/annotation-tool.js
@@ -1,5 +1,5 @@
 function AnnotationTool(parent){
-    
+
     var _self = this;
 
     this.elem = null;
@@ -27,10 +27,10 @@ function AnnotationTool(parent){
             return;
         }
 
-        
+
         _self.dispatchEvent("drawingStop");
         _self.updateMode(btnType);
-        
+
     }
 
     // Change stroke color. This function handles the flow when the color (stroke) is changed while drawing/editting the SVG.
@@ -49,7 +49,7 @@ function AnnotationTool(parent){
 
     // Render the view
     this.render = function(data){
-        
+
         var toolElem = null,
             colorInput = null;
             _self = this;
@@ -79,28 +79,30 @@ function AnnotationTool(parent){
                 // "<span class='toolBtn' data-type='SAVE'>",
                 //     "<i class='fa fa-floppy-o'></i>",
                 // "</span>",
-                
+
             ].join("");
-    
+
             toolElem.querySelector(".toolBtn[data-type='"+this.curType+"']").className = "toolBtn selected";
             this.elem = toolElem;
-    
+
             // Binding events
             this.elem.querySelectorAll(".toolBtn").forEach(function(elem){
                 elem.addEventListener('click', this.onClickChangeBtn);
             }.bind(this));
-    
+
             colorInput = this.elem.querySelector("#strokeColor");
             colorInput.addEventListener('change', this.onChangeStrokeColor);
         }
         else{
             colorInput = this.elem.querySelector("#strokeColor");
-            colorInput.setAttribute("value", this.curStroke);
+            // if a user changes the value, setAttribute doesn't work properly,
+            // so we have to use .value here
+            colorInput.value = this.curStroke;
             this.elem.querySelectorAll(".toolBtn").forEach(function(elem){
                 elem.className = (elem.getAttribute("data-type") === _self.curType) ?  "toolBtn selected" : "toolBtn";
             });
         }
-        
+
     }
 
     // Update the drawing info
@@ -114,7 +116,15 @@ function AnnotationTool(parent){
                     this.curGroupID = data.groupID;
                     break;
                 case "stroke":
-                    this.curStroke = data.stroke;
+                    if (data.stroke && typeof data.stroke === "string") {
+                        // the given color might not be understandable by input,
+                        // so we have to change it into hex instead
+                        var ctx = document.createElement("canvas").getContext("2d");
+                        ctx.fillStyle = data.stroke;
+
+                        // get the computed value
+                        this.curStroke = ctx.fillStyle;
+                    }
                     break;
                 case "type":
                     this.curType = data.type ? data.type : "CURSOR";
@@ -123,18 +133,18 @@ function AnnotationTool(parent){
             }
         }
     }
-    
+
     // Update the current mode
     this.updateMode = function(mode){
-       
+
         if(!_self.elem){
             return;
         }
-        
+
         _self.elem.querySelector(".toolBtn[data-type='"+_self.curType+"']").className = "toolBtn";
         _self.curType = mode || 'CURSOR';
         _self.elem.querySelector(".toolBtn[data-type='"+_self.curType+"']").className = "toolBtn selected";
-        
+
         switch(_self.curType){
             case "CURSOR":
                 _self.dispatchEvent("setMode", {

--- a/js/utils/util.js
+++ b/js/utils/util.js
@@ -176,12 +176,35 @@ Utils.prototype.getParameters = function(){
     return parameters;
 }
 
+/**
+ * Given an string for a color, turn it into a standard hex value
+ * @param {string} color
+ */
+Utils.prototype.standardizeColor = function (color) {
+    var ctx = document.createElement("canvas").getContext("2d");
+    ctx.fillStyle = color;
+    return ctx.fillStyle;
+};
+
 // Generate a random color
-Utils.prototype.generateColor = function(){
-    var letters = '0123456789ABCDEF',
+Utils.prototype.generateColor = function(usedColors){
+    var letters = '0123456789abcdef',
         color = '#',
         i;
 
+    var colorPallete = ["#d5ff00", "#00ff00", "#ff937e", "#91d0cb", "#0000ff",
+        "#00ae7e", "#ff00f6", "#5fad4e", "#01d0ff", "#bb8800", "#bdc6ff", "#008f9c",
+        "#a5ffd2", "#ffa6fe", "#ffdb66", "#00ffc6", "#00b917", "#bdd393", "#004754",
+        "#010067", "#0e4ca1", "#005f39", "#6b6882", "#683d3b", "#43002c", "#788231"];
+
+    //find a color from the pallete that is not used
+    for (i = 0; i < colorPallete.length; i++) {
+        if (usedColors.indexOf(colorPallete[i]) === -1) {
+            return colorPallete[i];
+        }
+    }
+
+    // otherwise generate a random color
     for (i = 0; i < 6; i++) {
         color += letters[Math.floor(Math.random() * 16)];
     }

--- a/js/viewer/annotation/annotation-group.js
+++ b/js/viewer/annotation/annotation-group.js
@@ -16,7 +16,7 @@ function AnnotationGroup(id, anatomy, description, parent){
     this.svg = null;
     this.isDisplay = true;
     this.isSelected = false;
-    
+
     // the stroke that is used by annotations in this group
     this.stroke = [];
 
@@ -31,32 +31,32 @@ function AnnotationGroup(id, anatomy, description, parent){
         }
         switch (type.toUpperCase()) {
             case "PATH":
-                annotation = new Path(attrs); 
+                annotation = new Path(attrs);
                 break;
             case "POLYLINE":
-                annotation = new Polyline(attrs); 
+                annotation = new Polyline(attrs);
                 break;
             case "POLYGON":
-                annotation = new Polygon(attrs); 
+                annotation = new Polygon(attrs);
                 break;
             case "RECT":
-                annotation = new Rect(attrs); 
+                annotation = new Rect(attrs);
                 break;
             case "CIRCLE":
-                annotation = new Circle(attrs); 
+                annotation = new Circle(attrs);
                 break;
         };
 
         if(annotation != null){
             this.annotations.push(annotation);
         }
-        
+
         return annotation;
     }
 
     // Dispatch the event to the parent
     this.dispatchEvent = function(type, data){
-        
+
         switch(type){
             case "onClickChangeSelectingAnnotation":
                 data["groupID"] = this.id;
@@ -137,15 +137,15 @@ function AnnotationGroup(id, anatomy, description, parent){
         })
     }
 
-    // Render a g container to contain annotation objects 
+    // Render a g container to contain annotation objects
     this.render = function(){
 
         var svg = d3.select(this.parent.svg)
             .append("g")
             .attr("id", this.id);
-            
+
         this.svg = svg;
-    
+
     }
 
     // Remove an annotation by graphID
@@ -161,7 +161,7 @@ function AnnotationGroup(id, anatomy, description, parent){
         if(!annotation){
             return
         }
-        
+
         // remove annotation object from the collection
         this.annotations.splice(index, 1);
 
@@ -172,7 +172,7 @@ function AnnotationGroup(id, anatomy, description, parent){
         annotation.svg.remove();
     }
 
-    // Remove all annotations 
+    // Remove all annotations
     this.removeAllAnnotations = function(){
         for(var i = 0; i < this.annotations.length; i++){
             this.removeAnnotationByID(this.annotations[i].id);
@@ -182,9 +182,9 @@ function AnnotationGroup(id, anatomy, description, parent){
     this.setAttributesByJSON = function(attrs){
         var attr,
             value;
-    
+
         for(attr in attrs){
-            value = attrs[attr];        
+            value = attrs[attr];
             switch(attr){
                 case "description":
                 case "anatomy":
@@ -199,7 +199,7 @@ function AnnotationGroup(id, anatomy, description, parent){
         this.isDisplay = isDisplay;
         this.svg.attr("display", displayStyle);
     }
-    
+
     this.updateDiagonalPoints = function(){
 
         // Set the annotation group boundaries based on the annotation
@@ -218,13 +218,14 @@ function AnnotationGroup(id, anatomy, description, parent){
             annotation.renderSVG();
         })
     }
-    
+
     /**
      * Given an annotation, will update the this.stroke Array
      * @param {Base} annot
      */
     this.setGroupStrokeByAnnotation = function (annot) {
-        var stroke = annot._attrs.stroke;
+        var stroke = _self.parent.parent._utils.standardizeColor(annot._attrs.stroke);
+
         if (_self.stroke.indexOf(stroke) === -1) {
             _self.stroke.push(stroke);
         }
@@ -235,6 +236,8 @@ function AnnotationGroup(id, anatomy, description, parent){
     * @param {string} stroke the RGB value of the new color
     */
     this.updateStroke = function(stroke) {
+        var stroke = _self.parent.parent._utils.standardizeColor(stroke);
+
         _self.stroke = [stroke];
         _self.annotations.forEach(function (annotation) {
             annotation._attrs.stroke = stroke;

--- a/js/viewer/annotation/annotation-svg.js
+++ b/js/viewer/annotation/annotation-svg.js
@@ -224,7 +224,7 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
      */
     this.exportToSVG = function(groupID){
         var rst = [];
-        var svg = "", stroke;
+        var svg = "";
         var imgScaleX = (this.imgScaleX) ? this.imgScaleX : 1;
         var imgScaleY = (this.imgScaleY) ? this.imgScaleY : 1;
 
@@ -236,20 +236,12 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
                 svg += this.groups[groupID].exportToSVG();
                 svg += "</svg>";
 
-                stroke = this.groups[groupID].stroke;
-                // TODO there might be a better way to do this
-                // if in create mode, you don't change the color, this value will
-                // be empty. This check will make sure that it's not empty and uses the default
-                if (!Array.isArray(stroke) || stroke.length === 0) {
-                    stroke = [this.parent.all_config.constants.DEFAULT_SVG_STROKE];
-                }
-
                 rst.push({
                     svgID : this.id,
                     groupID : groupID,
                     numOfAnnotations : this.groups[groupID].getNumOfAnnotations(),
                     svg : svg,
-                    stroke: stroke
+                    stroke: this.groups[groupID].stroke
                 });
             }
         }
@@ -261,15 +253,10 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
                 svg += this.groups[groupID].exportToSVG();
                 svg += "</svg>";
 
-                stroke = this.groups[groupID].stroke;
-                if (!Array.isArray(stroke) || stroke.length === 0) {
-                    stroke = [this.parent.all_config.constants.DEFAULT_SVG_STROKE];
-                }
-
                 rst.push({
                     groupID : groupID,
                     svg : svg,
-                    stroke: stroke
+                    stroke: this.groups[groupID].stroke
                 });
             }
         }
@@ -528,9 +515,6 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
                         annotation = group.addAnnotation(node.nodeName);
                         annotation.setAttributesByJSON(this.getNodeAttributes(node));
                         annotation.renderSVG(this);
-
-                        // make sure stroke value in group is based on annotations
-                        group.setGroupStrokeByAnnotation(annotation);
                     }
                     break;
                 case "scale":

--- a/js/viewer/annotation/base.js
+++ b/js/viewer/annotation/base.js
@@ -9,7 +9,7 @@ function Base(attrs){
 
     // this is used to make sure that any property that is added to the SVG for display purpose, is not added while saving
     this._addedAttributeNames = ["vector-effect"];
-    
+
     // if this url parameter exists, we should honor the stroke width that are defined on SVG files
     if (!this.urlParams.enableSVGStrokeWidth) {
         this._addedAttributeNames.push("stroke-width");
@@ -27,7 +27,7 @@ function Base(attrs){
 
     // it stores all the attributes that we are not handling right now, so that they can be added to the output SVG file
     this._ignoredAttrs = {};
-    
+
     /**
      * This functions checks to see if the svg component has valid attributes for it to be drawn. This function makes sure that no empty attribute is added.
      * @param {object} attributes
@@ -56,7 +56,7 @@ function Base(attrs){
             if (!this._attrs[attr] || this._attrs[attr] === null){
                 continue;
             }
-            
+
             // don't add the attributes that are added by osd viewer
             if (this._addedAttributeNames.indexOf(attr) !== -1) {
                 continue;
@@ -169,21 +169,21 @@ Base.prototype.highlight = function(highlightAttrs){
 }
 
 Base.prototype.renderSVG = function(){
-    
+
     var attr,
         value,
         strokeScale = this.parent.getStrokeScale() || 1;
 
-    if(this.svg == null){ 
+    if(this.svg == null){
         this.svg = this.parent.svg
             .append(this._tag)
             .attr("class", "annotation")
-        
+
         this.svg.on("mouseover", this.onMouseoverShowTooltip)
             .on("mousemove", this.onMousemoveShowTooltip)
             .on("mouseout", this.onMouseoutHideTooltip)
             .on('click', this.onClickToSelectAnnotation);
-            
+
         // prevent the default behavior of osd by adding an empty click handler
         new OpenSeadragon.MouseTracker({
             element: this.svg.node(),
@@ -192,7 +192,7 @@ Base.prototype.renderSVG = function(){
             }
         });
     }
-    
+
     // add all the attributes
     for(attr in this._attrs){
         value = this._attrs[attr];
@@ -215,7 +215,7 @@ Base.prototype.setAttributesByJSON = function(attrs){
         }
 
         value = attrs[attr];
-        
+
         // if it's any of the attributes that we should ignore
         if (!(attr in this._attrs) || this._addedAttributeNames.indexOf(attr) !== -1) {
             this._ignoredAttrs[attr] = value;
@@ -223,6 +223,9 @@ Base.prototype.setAttributesByJSON = function(attrs){
             this._attrs[attr] = value;
         }
     }
+
+    // update the stroke in the group
+    this.parent.setGroupStrokeByAnnotation(this);
 }
 
 Base.prototype.unHighlight = function(){
@@ -237,7 +240,7 @@ Base.prototype.unHighlight = function(){
 
 Base.prototype.unbind = function(){
 
-    if(this.svg == null){         
+    if(this.svg == null){
         this.svg.on("mouseover", null)
             .on("mousemove", null)
             .on("mouseout", null)


### PR DESCRIPTION
This PR implements what's described in #44 to have a better default color for the annotation toolbar.

To summarize,
- In edit mode, it will use the annotation color.
- In create mode, it will
   - pick the first unused color from the [color palette described here](https://github.com/informatics-isi-edu/gudmap-rbk/wiki/Color-palette-for-annotating-histological-images)
   - or if all the colors were used, it will use a random color.