### PR TITLE
Static multi-channel support for iiif images

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -43,7 +43,6 @@ var myApp = (function (_config) {
                 break;
             // Change openseadragon item channel setting
             case "changeOsdItemChannelSetting":
-                console.log("This is being called");
                 viewer.setItemChannel(data);
                 break;
             case "zoomIn":
@@ -103,6 +102,9 @@ var myApp = (function (_config) {
                 window.parent.postMessage({messageType: type, content: data}, window.location.origin);
                 break;
             case "osdInitialized":
+                window.parent.postMessage({messageType: type, content: data}, window.location.origin);
+                break;
+            case "osdInitializeFailed":
                 window.parent.postMessage({messageType: type, content: data}, window.location.origin);
                 break;
             case "downloadViewDone":

--- a/js/config.js
+++ b/js/config.js
@@ -7,7 +7,7 @@ var _config = {
         }
     },
     viewer : {
-        tiff : {
+        iiif : {
           svg: {
               id : 'annotationContainer'
           },

--- a/js/config.js
+++ b/js/config.js
@@ -28,7 +28,8 @@ var _config = {
             crossOriginPolicy: "Anonymous",
             constrainDuringPan: true,
             // collectionMode: true,
-            // tileSources : {}
+            // tileSources : {},
+            showNavigator: true //thumbnail
           },
           scalebar : {
               type: OpenSeadragon.ScalebarType.MAP,
@@ -53,6 +54,7 @@ var _config = {
             showHomeControl: false,
             showFullPageControl: false,
             constrainDuringPan: true,
+            showNavigator: true //thumbnail
           },
           scalebar : {
               type: OpenSeadragon.ScalebarType.MAP,

--- a/js/utils/util.js
+++ b/js/utils/util.js
@@ -110,7 +110,7 @@ Utils.prototype.getParameters = function(){
         type = args[i].split("=")[0];
         value = args[i].split("=")[1];
         switch(type){
-            case "url": // Parameter.type are of 3 types : svg - for annotation overlay, tiff - files containing info.json and all the other file formats are treated as rest
+            case "url": // Parameter.type are of 3 types : svg - for annotation overlay, iiif - files containing info.json and all the other file formats are treated as rest
                 // Note : SVG file could also used in other image types as well, needs to check the use case and modify in the future
                 // TODO the path of svg files are hardcoded and need to change
                 if(value.indexOf(".svg") != -1 || value.indexOf('resources/gene_expression/annotations') != -1){
@@ -123,19 +123,18 @@ Utils.prototype.getParameters = function(){
                 else if(value.indexOf("ImageProperties.xml") != -1){
                     parameters.images = parameters.images || [];
                     parameters.images.push(value);
-                    parameters.type = 'xml';
+                    parameters.type = 'dzi';
                 }
                 else if(value.indexOf("info.json") != -1) {
-                    parameters.info = parameters.info || [];
-                    parameters.info.push(value);
-                    parameters.type = 'tiff';
+                    parameters.images = parameters.images || [];
+                    parameters.images.push(value);
+                    parameters.type = 'iiif';
                 } else {
                     parameters.images = parameters.images || [];
                     parameters.images.push(value);
                     parameters.type = 'rest';
                 }
                 break;
-            // case "aliasName": // Move to channelName - basically to add as an array
             case "waterMark":
                 if( (value[0] == "\"" && value[value.length-1] == "\"") || (value[0] == "\'" && value[str.length-1] == "\'")){
                     value = value.substr(1,value.length-2);
@@ -215,10 +214,10 @@ Utils.prototype.generateColor = function(usedColors){
 Utils.prototype.setOsdConfig =  function(parameters, configs) {
   var config = null;
   switch (parameters.type) {
-    case "tiff":
-      config = configs.tiff;
+    case "iiif":
+      config = configs.iiif;
       break;
-    case "xml":
+    case "dzi":
       configs.rest.osd.showNavigator = true;
       config = configs.rest;
       break;

--- a/js/utils/util.js
+++ b/js/utils/util.js
@@ -215,7 +215,6 @@ Utils.prototype.setOsdConfig =  function(parameters, configs) {
       config = configs.iiif;
       break;
     case "dzi":
-      configs.rest.osd.showNavigator = true;
       config = configs.rest;
       break;
     case "rest":

--- a/js/utils/util.js
+++ b/js/utils/util.js
@@ -117,9 +117,6 @@ Utils.prototype.getParameters = function(){
                     parameters.svgs = parameters.svgs || [];
                     parameters.svgs.push(value);
                 }
-                // TODO the following conidtion was removed. we should figure out why it was added
-                // I removed it because we're not supposed to show thumbnail for jpg files
-                //  || value.indexOf(".jpg") != -1
                 else if(value.indexOf("ImageProperties.xml") != -1){
                     parameters.images = parameters.images || [];
                     parameters.images.push(value);

--- a/js/viewer/channel/channel.js
+++ b/js/viewer/channel/channel.js
@@ -3,6 +3,8 @@ function Channel(osdItemID, options) {
     var _self = this;
     this.id = osdItemID;
     this.name = options["channelName"] || "";
+    this.name = this.name.replace(/\_/g, " ");
+
     this.rgb = options["channelRGB"] || null;
     this.opacity = options["channelAlpha"] || 1;;
     this.width = +options["width"] || 0;

--- a/js/viewer/channel/channel.js
+++ b/js/viewer/channel/channel.js
@@ -31,20 +31,20 @@ Channel.prototype.colorMapping = {
     // red
     'Rhodamine': '1.000000 0.000000 0.000000',
     'RFP': '1.000000 0.000000 0.000000',
-    'Alexa Fluor 555': '1.000000 0.000000 0.000000', // based on xml
+    'Alexa Fluor 555': '1.000000 0.000000 0.000000',
     'Alexa Fluor 594': '1.000000 0.000000 0.000000',
     'tdTomato': '1.000000 0.000000 0.000000',
     'Alexa Fluor 633': '1.000000 0.000000 0.000000',
-    'Alexa Fluor 647': '1.000000 1.000000 0.000000', // based on xml
+    'Alexa Fluor 647': '1.000000 0.000000 0.000000',
 
     //green
     'FITC': '0.000000 1.000000 0.000000',
     'Alexa 488': '0.000000 1.000000 0.000000',
     'EGFP': '0.000000 1.000000 0.000000',
-    'Alexa Fluor 488': '0.000000 1.000000 0.200000', // based on xml
+    'Alexa Fluor 488': '0.000000 1.000000 0.000000',
 
     //blue
-    'DAPI': '0.000000 0.000000 1.000000' // based on xml
+    'DAPI': '0.000000 0.000000 1.000000'
 }
 
 Channel.prototype.getFiltersList = function () {

--- a/js/viewer/channel/channel.js
+++ b/js/viewer/channel/channel.js
@@ -1,8 +1,9 @@
-function Channel(osdItemID, options) {
+function Channel(osdItemID, name, options) {
+    options = options || {};
 
     var _self = this;
     this.id = osdItemID;
-    this.name = options["channelName"] || "";
+    this.name = (typeof name === "string") ? name : "";
     this.name = this.name.replace(/\_/g, " ");
 
     this.rgb = options["channelRGB"] || null;
@@ -25,9 +26,26 @@ function Channel(osdItemID, options) {
     this.setDefaultGamma();
 }
 
-Channel.prototype.redColors = ['Rhodamine', 'RFP', 'Alexa Fluor 555', 'Alexa Fluor 594', 'tdTomato', 'Alexa Fluor 633', 'Alexa Fluor 647'];
-Channel.prototype.greenColors = ['FITC', 'Alexa 488', 'EGFP', 'Alexa Fluor 488'];
-Channel.prototype.blueColors = ['DAPI'];
+
+Channel.prototype.colorMapping = {
+    // red
+    'Rhodamine': '1.000000 0.000000 0.000000',
+    'RFP': '1.000000 0.000000 0.000000',
+    'Alexa Fluor 555': '1.000000 0.000000 0.000000', // based on xml
+    'Alexa Fluor 594': '1.000000 0.000000 0.000000',
+    'tdTomato': '1.000000 0.000000 0.000000',
+    'Alexa Fluor 633': '1.000000 0.000000 0.000000',
+    'Alexa Fluor 647': '1.000000 1.000000 0.000000', // based on xml
+
+    //green
+    'FITC': '0.000000 1.000000 0.000000',
+    'Alexa 488': '0.000000 1.000000 0.000000',
+    'EGFP': '0.000000 1.000000 0.000000',
+    'Alexa Fluor 488': '0.000000 1.000000 0.200000', // based on xml
+
+    //blue
+    'DAPI': '0.000000 0.000000 1.000000' // based on xml
+}
 
 Channel.prototype.getFiltersList = function () {
     var list = [];
@@ -98,12 +116,9 @@ Channel.prototype.setDefaultHue = function () {
               this.hue = null;
               break;
           default:
-              // Blue colors
-              this.hue = this.blueColors.indexOf(this.name) != -1 ? 240 : this.hue;
-              // Green colors
-              this.hue = this.greenColors.indexOf(this.name) != -1 ? 120 : this.hue;
-              // Red colors
-              this.hue = this.redColors.indexOf(this.name) != -1 ? 0 : this.hue;
+              if (this.name in this.colorMapping) {
+                  this.hue = hueIs(this.colorMapping[this.name]);
+              }
               break;
       }
     }
@@ -112,8 +127,7 @@ Channel.prototype.setDefaultHue = function () {
 }
 
 Channel.prototype.setDefaultGamma = function () {
-
-    if (this.blueColors.indexOf(this.name) != -1 || this.greenColors.indexOf(this.name) != -1 || this.redColors.indexOf(this.name) != -1) {
+    if (this.name in this.colorMapping) {
         this.gamma = 0.75;
         this.initialProperty.gamma = this.gamma;
     };

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -51,6 +51,12 @@ function Viewer(parent, config) {
         this._config = this._utils.setOsdConfig(this.parameters, this.all_config);
         // console.log("Config used: ",  this._config, this.parameters);  // TODO: If config is null, give an error.
 
+        // configure osd
+        this.osd = OpenSeadragon(this._config.osd);
+
+        // add the scalebar (might change based on the images)
+        this.osd.scalebar(this._config.scalebar);
+
         // load the images
         this.loadImages(this.parameters)
 
@@ -58,9 +64,6 @@ function Viewer(parent, config) {
         this.svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
         this.svg.setAttribute("id", 'annotationContainer');
         this.osd.canvas.append(this.svg);
-
-        // add the scalebar
-        this.osd.scalebar(this._config.scalebar);
 
         // after each resize, make sure svgs are properly positioned
         this.osd.addHandler('resize', this.resizeSVG);
@@ -628,9 +631,6 @@ function Viewer(parent, config) {
 
     // Load Image and Channel information
     this.loadImages = function (params) {
-        // configure osd
-        this.osd = OpenSeadragon(this._config.osd);
-
         var urls = params.images || [], channelList = [], i;
 
         // process the images


### PR DESCRIPTION
Summary of changes in this PR:
- Changed `xml` to`dzi` and `tiff` to `iiif` to be more accurate.
 - Modified the `loadImages` function to properly create `TileSource` for each of the given images in the URL. The code will uniformly treat multiple image URLs as multi-channel view (previously for iiif it was treated as multi-scene.)
- Moved loadAfterOSDInit to be inside the add-item callback. this will ensure running the code after all the images are loaded.
- Removed the unnecessary `tileWidth` and `tileHeight` from `tileSource` of non-iiif non-dzi images.
- Removed the unnecessary code piece that was adding `channelNames` outside of `loadImages`. channels must have an image associated with them, so they should be added only in the `loadImages` function.
- Add 'add-item-failed' event handler to make sure we're properly informing chaise about load failures.
- Moved the annotation SVG code so we can have annotation on all the image types. The annotation support was just added to `iiif` images as a proof of concept, but there's really no reason to limit it only to those types of images.
- Modified how we're doing color mapping in `channel.js`. The code will apply a hue based on rgb color instead of just red, green, and blue colors. This has been done just for consistency. The rgb value still going to be pure red, green, or blue.
- Modified the behavior of app to always show the thumbnail regardless of image type.

I updated the regression tests to include proper links and tested it with the new links and everything seems to be functional.

related epic: #49