### PR TITLE
Dynamic multi-channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,23 +41,171 @@ https://github.com/openseadragon/svg-overlay
 
 Paremeters may be passed to openseadragon-viewer as URL query parameters.  
 
-| Parameter | Value | Description |
-| --- | --- | --- |
-| **url** | URL | one or more input url to an ImageProperties.xml(DZI image pyramid), AnnotationData.xml(third-party annotation data file), or  datafile.jpg(simple image jpg) |
-| **x** | float | set initial X |
-| **y** | float | set initial Y |
-| **z** | float | set initial zoom |
-| **meterScaleInPixels** | float | set scale, pixels in a meter, usually set within DZI's metadata |
-| **channelName** | chars | set channel name of the matching URL image.  The channel is either one of ('Rhodamine', 'RFP', 'Alexa Fluor 555', 'Alexa Fluor 594', 'tdTomato', 'Alexa Fluor 633', 'Alexa Fluor 647') for red, one of ('FITC', 'Alexa 488', 'EGFP', 'Alexa Fluor 488' ) for green, one of ('DAPI') for blue or one of ('TL Brightfield' or 'combo') for colorized RGB or if none specified.  This name can also be extracted from ImageProperties.xml |
-| **aliasName** | chars | set name to be used for pull-out listing for this URL image |
-| **waterMark** | chars | set watermark to add credit to snapshot jpg image |
-| **scale** | float | This scale corresponds to the unit used in the provided SVG. For example, a given `viewBox (0, 0, 3830.84, 4059.58)` and a `scale=0.21951` will convert to `width = 17451` and `height=18493`
-| **ignoreReferencePoint** | boolean | set `true` (default) to ignore the reference point in the svg `viewBox`, which the upper-left point will be `0,0`. set to `false` to honor the provided upper-left point. If set to `false` and `scale` is provided, the reference point will be converted based on the provided scale.
-| **ignoreDimension** | boolean | set `true` (default) to ignore the provided width and height in the svg `viewBox`, which the bottom-right point will be the size of `tif` image width and height. set `false` to honor the provided bottom-right point. If set to `false` and `scale` is provided, the bottom-right point will be converted based on the provided scale.
-| **enableSVGStrokeWidth** | boolean | set `false` (default) to ignore the `stroke-width` present in the SVG file, which implies that the SVG drawn in the OSD will use `DEFAULT_LINE_THICKNESS` defined as a constant in the system as the `stroke-width`. If set to `true`, it will use the `stroke-width` mentioned in the SVG file.
-| **zoomLineThickness** | string | The value of this param decides which function should be used to determine the line thickness at a particular zoom level. `log`: the thickness vaires according to the log of the current zoom level. Since at each zoom in/out the zoom level changes by a factor of 2, i.e. it changes exponentially, therefore using a log approach provides linear change in line-thickness with respect to each zoom in/out click. `default`: using the original function, i.e. mapping the line thickness linearly with the total zoom levels avaibale in the OSD
+### Channel parameters
+Since we support a mulit-channel view of image. There can be multiple values for these query parameters. Each will represent a channel and will modify the settings related to that.
 
-## Usage of the `scale`, `ignoreReferencePoint`, `ignoreDimension` parameters
+<table>
+  <tbody>
+    <tr>
+      <th>Parameter</th>
+      <th>Value</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+        <td><strong>url</strong></td>
+        <td>URL</td>
+        <td>
+            (required) one or more input url to an image source. Available image source types:
+            <ul>
+                <li>dzi images: ImageProperties.xml</li>
+                <li>iiif images: info.json</li>
+                <li>annotation images: SVG files stored in hatrac</li>
+                <li>Any other image source supported by OSD</li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <td><strong>channelName</strong></td>
+        <td>String</td>
+        <td>
+            set channel name of the matching URL image.  The channel can be any non-empty strings. The following specific channel names can be used for proper color filters:
+            <ul>
+                <li>
+                    far red (magenta): <code>Alexa Fluor 633</code>, <code>Alexa Fluor 647</code>
+                </li>
+                <li>
+                    red: <code>Rhodamine</code>, <code>RFP</code>, <code>Alexa Fluor 555</code>, <code>Alexa Fluor 594</code>, <code>tdTomato</code>, <code>mcherry</code>
+                </li>
+                <li>
+                    green: <code>FITC</code>, <code>Alexa 488</code>, <code>Alexa Fluor 488</code>, <code>EGFP</code>
+                </li>
+                <li>
+                    blue: <code>DAPI</code>, <code>Hoechst</code>
+                </li>
+                <li>
+                    colorized RGB (no hue filter applied): 'TL Brightfield', 'combo'
+                </li>
+            </ul>
+            For dzi images, if the channelName is missing, it will be derived from the ImageProperties.xml file.
+            We will apply a "white" hue filter if the channelName is not any of the mentioned values.
+        </td>
+    </tr>
+    <tr>
+        <td><strong>aliasName</strong></td>
+        <td>string</td>
+        <td>
+            set name to be used for pull-out listing for this URL image
+        </td>
+    </tr>
+    <tr>
+        <td><strong>isRGB</strong></td>
+        <td>boolean</td>
+        <td>
+            set <code>true</code> to avoid applying any hue filter and use the image as is.
+        </td>
+    </tr>
+    <tr>
+        <td><strong>pseudoColor</strong></td>
+        <td>string</td>
+        <td>
+            set the hue color filter that should be applied. The color value must be in <a target="_blank" href="https://en.wikipedia.org/wiki/Web_colors#Hex_triplet">Hex triplet format</a>, e.g., <code>#00ff00</code>. This will override the default color that might be dictated by the <code>channelName</code>. If <code>isRGB</code> is set to <code>true</code>, this variable will be ignored.
+        </td>
+    </tr>
+  </tbody>
+</table>
+
+### General parameters
+
+The following are general parameters that will be applied to the whole view:
+
+<table>
+  <tbody>
+    <tr>
+      <th>Parameter</th>
+      <th>Value</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+        <td><strong>x</strong></td>
+        <td>float</td>
+        <td>
+            set initial X
+        </td>
+    </tr>
+    <tr>
+        <td><strong>y</strong></td>
+        <td>float</td>
+        <td>
+            set initial y
+        </td>
+    </tr>
+    <tr>
+        <td><strong>z</strong></td>
+        <td>float</td>
+        <td>
+            set initial zoom
+        </td>
+    </tr>
+    <tr>
+        <td><strong>meterScaleInPixels</strong></td>
+        <td>float</td>
+        <td>
+            set scale, pixels in a meter, usually set within DZI's metadata
+        </td>
+    </tr>
+    <tr>
+        <td><strong>waterMark</strong></td>
+        <td>string</td>
+        <td>
+            set watermark to add credit to snapshot jpg image
+        </td>
+    </tr>
+    <tr>
+        <td><strong>scale</strong></td>
+        <td>float</td>
+        <td>
+            This scale corresponds to the unit used in the provided SVG. For example, a given <code>viewBox (0, 0, 3830.84, 4059.58)</code> and a <code>scale=0.21951</code> will convert to <code>width=17451</code> and <code>height=18493</code>
+        </td>
+    </tr>
+    <tr>
+        <td><strong>ignoreReferencePoint</strong></td>
+        <td>boolean</td>
+        <td>
+            set <code>true</code> (default) to ignore the reference point in the svg <code>viewBox</code>, which the upper-left point will be <code>0,0</code>. set to false to honor the provided upper-left point. If set to <code>false</code> and <code>scale</code> is provided, the reference point will be converted based on the provided scale.
+        </td>
+    </tr>
+    <tr>
+        <td><strong>ignoreDimension</strong></td>
+        <td>boolean</td>
+        <td>
+            set <code>true</code> (default) to ignore the provided width and height in the svg <code>viewBox</code>, which the bottom-right point will be the size of image width and height. set <code>false</code> to honor the provided bottom-right point. If set to <code>false</code> and <code>scale</code> is provided, the bottom-right point will be converted based on the provided scale.
+        </td>
+    </tr>
+    <tr>
+        <td><strong>enableSVGStrokeWidth</strong></td>
+        <td>boolean</td>
+        <td>
+            set <code>false</code> (default) to ignore the <code>stroke-width</code> present in the SVG file, which implies that the SVG drawn in the OSD will use <code>DEFAULT_LINE_THICKNESS</code> defined as a constant in the system as the <code>stroke-width</code>. If set to <code>true</code>, it will use the <code>stroke-width</code> mentioned in the SVG file.
+        </td>
+    </tr>
+    <tr>
+        <td><strong>zoomLineThickness</strong></td>
+        <td>string</td>
+        <td>
+            The value of this param decides which function should be used to determine the line thickness at a particular zoom level.
+            <ul>
+                <li>
+                    <code>log</code>: the thickness vaires according to the log of the current zoom level. Since at each zoom in/out the zoom level changes by a factor of 2, i.e. it changes exponentially, therefore using a log approach provides linear change in line-thickness with respect to each zoom in/out click.
+                </li>
+                <li>
+                    <code>default</code>: using the original function, i.e. mapping the line thickness linearly with the total zoom levels avaibale in the OSD
+                </li>
+            </ul>
+        </td>
+    </tr>
+</table>
+
+#### Usage of the `scale`, `ignoreReferencePoint`, `ignoreDimension` parameters
 
 - **Case 1 : Provided SVG has the same aspect ratio as the loaded `tif` image**
 

--- a/css/container.css
+++ b/css/container.css
@@ -6,3 +6,12 @@
 }
 
 
+#openseadragonSpinner {
+    display: none;
+    position: absolute;
+    right: 5px;
+    top: 5px;
+    font-size: 20px;
+    z-index: 1;
+    color: white;
+}

--- a/css/toolbar/channel-item.css
+++ b/css/toolbar/channel-item.css
@@ -1,6 +1,7 @@
 #navMenuContent .groups .channelItem{
     /* border-bottom: 1px solid #cecece; */
     padding: 10px 0;
+    white-space: nowrap;
 }
 
 #navMenuContent .groups .channelItem .channelRow{
@@ -75,6 +76,24 @@
     flex-direction: column;
 }
 
+#navMenuContent .groups .channelItem .hue-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 0 5px;
+}
+
+#navMenuContent .groups .channelItem .deactivate-hue {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #ccc;
+    cursor: pointer;
+}
+
+
 #navMenuContent .groups .channelItem input.slider{
     -webkit-appearance: none;
     appearance: none;
@@ -90,32 +109,34 @@
 }
 
 #navMenuContent .groups .channelItem .sliderContainer[data-type="hue"] input.slider{
+    width: 195px;
+    margin: 0;
     background: -webkit-linear-gradient(left, hsla(0, 100%, 50%, 1),
-   hsla(10, 100%, 50%, 1),hsla(20, 100%, 50%, 1),hsla(30, 100%, 50%, 1),
-   hsla(40, 100%, 50%, 1),hsla(50, 100%, 50%, 1),hsla(60, 100%, 50%, 1),
-   hsla(70, 100%, 50%, 1),hsla(80, 100%, 50%, 1),hsla(90, 100%, 50%, 1),
-   hsla(100, 100%, 50%, 1),hsla(110, 100%, 50%, 1),hsla(120, 100%, 50%, 1),
-   hsla(130, 100%, 50%, 1),hsla(140, 100%, 50%, 1),hsla(150, 100%, 50%, 1),
-   hsla(160, 100%, 50%, 1),hsla(170, 100%, 50%, 1),hsla(180, 100%, 50%, 1),
-   hsla(190, 100%, 50%, 1),hsla(200, 100%, 50%, 1),hsla(210, 100%, 50%, 1),
-   hsla(220, 100%, 50%, 1),hsla(230, 100%, 50%, 1),hsla(240, 100%, 50%, 1),
-   hsla(250, 100%, 50%, 1),hsla(260, 100%, 50%, 1),hsla(270, 100%, 50%, 1),
-   hsla(280, 100%, 50%, 1),hsla(290, 100%, 50%, 1),hsla(300, 100%, 50%, 1),
-   hsla(310, 100%, 50%, 1),hsla(320, 100%, 50%, 1),hsla(330, 100%, 50%, 1),
-   hsla(340, 100%, 50%, 1),hsla(350, 100%, 50%, 1),hsla(360, 100%, 50%, 1));
-  background: -moz-linear-gradient(left, hsla(0, 100%, 50%, 1),
-   hsla(10, 100%, 50%, 1),hsla(20, 100%, 50%, 1),hsla(30, 100%, 50%, 1),
-   hsla(40, 100%, 50%, 1),hsla(50, 100%, 50%, 1),hsla(60, 100%, 50%, 1),
-   hsla(70, 100%, 50%, 1),hsla(80, 100%, 50%, 1),hsla(90, 100%, 50%, 1),
-   hsla(100, 100%, 50%, 1),hsla(110, 100%, 50%, 1),hsla(120, 100%, 50%, 1),
-   hsla(130, 100%, 50%, 1),hsla(140, 100%, 50%, 1),hsla(150, 100%, 50%, 1),
-   hsla(160, 100%, 50%, 1),hsla(170, 100%, 50%, 1),hsla(180, 100%, 50%, 1),
-   hsla(190, 100%, 50%, 1),hsla(200, 100%, 50%, 1),hsla(210, 100%, 50%, 1),
-   hsla(220, 100%, 50%, 1),hsla(230, 100%, 50%, 1),hsla(240, 100%, 50%, 1),
-   hsla(250, 100%, 50%, 1),hsla(260, 100%, 50%, 1),hsla(270, 100%, 50%, 1),
-   hsla(280, 100%, 50%, 1),hsla(290, 100%, 50%, 1),hsla(300, 100%, 50%, 1),
-   hsla(310, 100%, 50%, 1),hsla(320, 100%, 50%, 1),hsla(330, 100%, 50%, 1),
-   hsla(340, 100%, 50%, 1),hsla(350, 100%, 50%, 1),hsla(360, 100%, 50%, 1));
+        hsla(10, 100%, 50%, 1),hsla(20, 100%, 50%, 1),hsla(30, 100%, 50%, 1),
+        hsla(40, 100%, 50%, 1),hsla(50, 100%, 50%, 1),hsla(60, 100%, 50%, 1),
+        hsla(70, 100%, 50%, 1),hsla(80, 100%, 50%, 1),hsla(90, 100%, 50%, 1),
+        hsla(100, 100%, 50%, 1),hsla(110, 100%, 50%, 1),hsla(120, 100%, 50%, 1),
+        hsla(130, 100%, 50%, 1),hsla(140, 100%, 50%, 1),hsla(150, 100%, 50%, 1),
+        hsla(160, 100%, 50%, 1),hsla(170, 100%, 50%, 1),hsla(180, 100%, 50%, 1),
+        hsla(190, 100%, 50%, 1),hsla(200, 100%, 50%, 1),hsla(210, 100%, 50%, 1),
+        hsla(220, 100%, 50%, 1),hsla(230, 100%, 50%, 1),hsla(240, 100%, 50%, 1),
+        hsla(250, 100%, 50%, 1),hsla(260, 100%, 50%, 1),hsla(270, 100%, 50%, 1),
+        hsla(280, 100%, 50%, 1),hsla(290, 100%, 50%, 1),hsla(300, 100%, 50%, 1),
+        hsla(310, 100%, 50%, 1),hsla(320, 100%, 50%, 1),hsla(330, 100%, 50%, 1),
+        hsla(340, 100%, 50%, 1),hsla(350, 100%, 50%, 1),hsla(360, 100%, 50%, 1));
+    background: -moz-linear-gradient(left, hsla(0, 100%, 50%, 1),
+        hsla(10, 100%, 50%, 1),hsla(20, 100%, 50%, 1),hsla(30, 100%, 50%, 1),
+        hsla(40, 100%, 50%, 1),hsla(50, 100%, 50%, 1),hsla(60, 100%, 50%, 1),
+        hsla(70, 100%, 50%, 1),hsla(80, 100%, 50%, 1),hsla(90, 100%, 50%, 1),
+        hsla(100, 100%, 50%, 1),hsla(110, 100%, 50%, 1),hsla(120, 100%, 50%, 1),
+        hsla(130, 100%, 50%, 1),hsla(140, 100%, 50%, 1),hsla(150, 100%, 50%, 1),
+        hsla(160, 100%, 50%, 1),hsla(170, 100%, 50%, 1),hsla(180, 100%, 50%, 1),
+        hsla(190, 100%, 50%, 1),hsla(200, 100%, 50%, 1),hsla(210, 100%, 50%, 1),
+        hsla(220, 100%, 50%, 1),hsla(230, 100%, 50%, 1),hsla(240, 100%, 50%, 1),
+        hsla(250, 100%, 50%, 1),hsla(260, 100%, 50%, 1),hsla(270, 100%, 50%, 1),
+        hsla(280, 100%, 50%, 1),hsla(290, 100%, 50%, 1),hsla(300, 100%, 50%, 1),
+        hsla(310, 100%, 50%, 1),hsla(320, 100%, 50%, 1),hsla(330, 100%, 50%, 1),
+        hsla(340, 100%, 50%, 1),hsla(350, 100%, 50%, 1),hsla(360, 100%, 50%, 1));
 }
 
 /* Mouse-over effects */

--- a/css/toolbar/channel-item.css
+++ b/css/toolbar/channel-item.css
@@ -80,17 +80,35 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    align-items: baseline;
+    align-items: center;
     padding: 0 5px;
 }
 
 #navMenuContent .groups .channelItem .deactivate-hue {
     display: inline-block;
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background: #ccc;
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    background: #a6a4a4;
     cursor: pointer;
+    font-family: "Font Awesome 5 Pro";
+    font-weight: 900;
+    position: relative;
+}
+
+
+/* #navMenuContent .groups .channelItem .deactivate-hue.active {
+    border: 2px solid #6797d4;
+} */
+
+#navMenuContent .groups .channelItem .deactivate-hue.active:after {
+    position: absolute;
+    color: #4674A7;
+    top: 0;
+    left: 0;
+    content: "\f00c";
+    font: normal normal normal 14px/1 FontAwesome;
+    font-size: 12px;
 }
 
 
@@ -111,6 +129,7 @@
 #navMenuContent .groups .channelItem .sliderContainer[data-type="hue"] input.slider{
     width: 195px;
     margin: 0;
+    margin-right: 7px;
     background: -webkit-linear-gradient(left, hsla(0, 100%, 50%, 1),
         hsla(10, 100%, 50%, 1),hsla(20, 100%, 50%, 1),hsla(30, 100%, 50%, 1),
         hsla(40, 100%, 50%, 1),hsla(50, 100%, 50%, 1),hsla(60, 100%, 50%, 1),
@@ -149,11 +168,13 @@
 #navMenuContent .groups .channelItem input.slider::-webkit-slider-thumb {
     -webkit-appearance: none; /* Override default look */
     appearance: none;
-    width: 10px; /* Set a specific slider handle width */
+    width: 5px; /* Set a specific slider handle width */
     height: 10px; /* Slider handle height */
-    background: #d2d6da;
+    /* background: #d2d6da; */
+    background: white;
     cursor: pointer; /* Cursor on hover */
-    border: 1px solid #6797d4;
+    /* border: 1px solid #6797d4; */
+    border: 1px solid white;
     border-radius : 2px;
 }
 

--- a/css/toolbar/channel-list.css
+++ b/css/toolbar/channel-list.css
@@ -8,6 +8,13 @@
     padding: 10px 0;
 }
 
+
+#menuContainer #navMenuContent .channelList .title-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
 #menuContainer #navMenuContent .channelList .title{
     font-size: 14px;
     font-weight: bold;
@@ -22,8 +29,6 @@
     box-sizing: border-box;
     padding: 5px 10px 5px 10px;
     flex: 1;
-    overflow-y: auto;
-    /* border-radius: 5px; */
 }
 #navMenuContent .channelList .dismiss-channel {
   border:none;

--- a/css/toolbar/menuContainer.css
+++ b/css/toolbar/menuContainer.css
@@ -3,7 +3,6 @@
     /* display:-webkit-flex; */
     background: #2f2f2f;
     /* flex-direction: row; */
-    max-height: 50vw;
     position: absolute;
     top: 0;
     left: 5px;
@@ -13,6 +12,13 @@
     -moz-user-select: none;     /* Firefox all */
     -ms-user-select: none;      /* IE 10+ */
     user-select: none;          /* Likely future */
+
+    overflow: hidden;
+    max-height: 100%;
+}
+
+#menuContainer.expand {
+    overflow-y: auto;
 }
 
 #menuContainer #navMenu{
@@ -45,7 +51,6 @@
     font-family: sans-serif;
     flex-direction: column;
     font-size: 12px;
-    overflow: hidden;
     z-index: 1;
     /* border-right: 1px solid #cfcfcf; */
 }
@@ -78,4 +83,3 @@
     color: #656565;
     height: 20px;
 }
-

--- a/css/toolbar/menuContainer.css
+++ b/css/toolbar/menuContainer.css
@@ -19,6 +19,7 @@
 
 #menuContainer.expand {
     overflow-y: auto;
+    padding-right: 10px;
 }
 
 #menuContainer #navMenu{

--- a/js/app.js
+++ b/js/app.js
@@ -9,8 +9,16 @@ var myApp = (function (_config) {
         viewer = new Viewer(this, _config.viewer);
         toolbar = new ToolbarController(this, _config.toolbar);
 
-        viewer.init(utils);
+        // if there are query parameters, we should initialize viewer
+        var url = document.location.href;
+        if (url.indexOf("?") != -1) {
+            viewer.init(utils, utils.getQueryParams(url));
+        }
+
         window.addEventListener('message', receiveChaiseEvent);
+
+        // let parent window know that the app is loaded
+        window.parent.postMessage({messageType: 'osdLoaded'}, window.location.origin);
 
         this.viewer = viewer;
         this.toolbar = toolbar;
@@ -122,6 +130,9 @@ var myApp = (function (_config) {
             var messageType = event.data.messageType;
             var data = event.data.content;
             switch (messageType) {
+                case 'initializeViewer':
+                    viewer.init(utils, data);
+                    break;
                 case 'filterChannels':
                     toolbar && toolbar.onClickedMenuHandler('channelList');
                     break;

--- a/js/config.js
+++ b/js/config.js
@@ -12,7 +12,10 @@ var _config = {
               id : 'annotationContainer'
           },
           osd: { // Single and multiple
+            // debugMode: true,
             id: 'openseadragonContainer',
+            spinnerID: 'openseadragonSpinner',
+
             // prefixUrl: "images/",
             // collectionRows: 1,
             ajaxWithCredentials : true,
@@ -48,7 +51,9 @@ var _config = {
         },
         rest: {
           osd: {
+            // debugMode: true,
             id: 'openseadragonContainer',
+            spinnerID: 'openseadragonSpinner',
             // showNavigator: false,
             showZoomControl: false,
             showHomeControl: false,

--- a/js/toolbar/channel-item.js
+++ b/js/toolbar/channel-item.js
@@ -97,7 +97,7 @@ function ChannelItem(data){
         _self.parent.dispatchEvent('changeOsdItemChannelSetting', {
             id: _self.osdItemId,
             type : 'deactivateHue',
-            value : true
+            value : _self.deactivateHue
         });
 
         event.stopPropagation();

--- a/js/toolbar/channel-item.js
+++ b/js/toolbar/channel-item.js
@@ -10,9 +10,10 @@ function ChannelItem(data){
       this.hue = data["hue"]
     } else {
       this.hue = null;
-
     }
-    // this.hue = data["hue"] || null;
+
+    this.deactivateHue = data["deactivateHue"] || false;
+
     this.opacity = data["opacity"] || "";
     this.osdItemId = data["osdItemId"];
     this.parent = data.parent || null;
@@ -51,6 +52,25 @@ function ChannelItem(data){
         event.stopPropagation();
     };
 
+    this.onClickDeactivateHue = function (event) {
+        if (!_self.deactivateHue) {
+            _self.deactivateHue = true;
+
+            // change the displayed value
+            _self.hue = "None";
+            _self.elem.querySelector(".sliderContainer[data-type='hue'] .attrRow .value").innerText = "None";
+
+            // set te proper value
+            _self.parent.dispatchEvent('changeOsdItemChannelSetting', {
+                id: _self.osdItemId,
+                type : 'deactivateHue',
+                value : true
+            });
+        }
+
+        event.stopPropagation();
+    };
+
     // Change the slider value
     this.onChangeSliderValue = function(){
         var type = this.parentNode.getAttribute("data-type"),
@@ -72,6 +92,7 @@ function ChannelItem(data){
             case "hue":
                 _self.hue = value;
                 _self.elem.querySelector(".sliderContainer[data-type='hue'] .attrRow .value").innerText = value;
+                _self.deactivateHue = false;
                 break;
         };
 
@@ -119,9 +140,12 @@ function ChannelItem(data){
                 "<span class='sliderContainer' data-type='hue'>",
                     "<span class='attrRow'>",
                         "<span class='name'>Hue</span>",
-                        "<span class='value'>"+ this.hue +"</span>",
+                        "<span class='value'>"+ (this.deactivateHue ? "None" : this.hue) +"</span>",
                     "</span>",
-                    "<input type='range' class='slider' min='0' max='360' step='1' value='"+this.hue+"'>",
+                    "<span class='hue-container' data-type='hue'>",
+                        "<input type='range' class='slider' min='0' max='360' step='1' value='"+this.hue+"'>",
+                        "<span class='deactivate-hue'></span>",
+                    "</span>",
                 "</span>",
             "</div>",
         ].join("");
@@ -132,6 +156,11 @@ function ChannelItem(data){
         this.elem = channeElem;
 
         // Binding events
+
+        //
+        this.elem.querySelectorAll(".hue-container .deactivate-hue").forEach(function(elem){
+            elem.addEventListener('click', this.onClickDeactivateHue);
+        }.bind(this));
 
         // Change the visibility of Openseadragon items
         this.elem.querySelectorAll(".channelRow .toggleVisibility").forEach(function(elem){

--- a/js/toolbar/channel-list.js
+++ b/js/toolbar/channel-list.js
@@ -22,6 +22,7 @@ function ChannelList(parent){
                     brightness : items[i]["brightness"],
                     gamma : items[i]["gamma"],
                     hue : items[i]["hue"],
+                    deactivateHue: items[i]["deactivateHue"],
                     osdItemId : id,
                     parent : _self
                 });
@@ -56,13 +57,13 @@ function ChannelList(parent){
         listElem.setAttribute("class", "channelList");
         if (collection,Object.keys(collection).length === 0 && collection.constructor === Object) {
           listElem.innerHTML = [
-              "<div><span class='title'>Channels</span> <button class='dismiss-channel' title='dismiss'><i class='fa fa-times'></i></button></div>",
+              "<div class='title-container'><span class='title'>Channels</span> <button class='dismiss-channel' title='dismiss'><i class='fa fa-times'></i></button></div>",
               "<div class='groups'> No Channels found",
               "</div>"
           ].join("");
         } else {
           listElem.innerHTML = [
-              "<div><span class='title'>Channels</span> <button class='dismiss-channel' title='dismiss' style='border:none;background-color:transparent; float:right!important;'><i class='fa fa-times'></i></button></div>",
+              "<div class='title-container'><span class='title'>Channels</span> <button class='dismiss-channel' title='dismiss' style='border:none;background-color:transparent; float:right!important;'><i class='fa fa-times'></i></button></div>",
               "<div class='groups'>",
               "</div>"
           ].join("");

--- a/js/toolbar/channel-list.js
+++ b/js/toolbar/channel-list.js
@@ -68,7 +68,7 @@ function ChannelList(parent){
               "</div>"
           ].join("");
         }
-        console.log("Collection are herre",  collection,Object.keys(collection).length === 0 && collection.constructor === Object);
+        // console.log("Collection are herre",  collection,Object.keys(collection).length === 0 && collection.constructor === Object);
         for(id in collection){
             if(collection[id].elem == null){
                 collection[id].render();

--- a/js/toolbar/toolbar.view.js
+++ b/js/toolbar/toolbar.view.js
@@ -7,10 +7,10 @@ function ToolbarView(controller, config){
     this._containerElem = document.getElementById(config.elems.containerId);
     this._navMenuElem = document.getElementById(config.elems.navMenuId);
     this._navMenuContentElem = document.getElementById(config.elems.navMenuContentId);
-    this._drawToolElem = document.getElementById(config.elems.drawToolContainerId); 
+    this._drawToolElem = document.getElementById(config.elems.drawToolContainerId);
     this._types = config.navMenu;
     this._toolbarController = controller;
-    
+
     this.onClickMenuBtn = function(event){
         // Get menu button type clicked by the user
         var clickMenuType = this.getAttribute("data-type") || "";
@@ -23,7 +23,7 @@ function ToolbarView(controller, config){
     }
 
 
-    // Render the toolbar menu 
+    // Render the toolbar menu
     this.renderToolbarMenu = function(){
         for (key in this._types) {
             type = this._types[key];
@@ -41,11 +41,11 @@ function ToolbarView(controller, config){
 
         // Clear menu content
         this._navMenuContentElem.innerHTML = "";
-        // Render annotation list if it's null 
+        // Render annotation list if it's null
         if(annotationList.elem == null){
             annotationList.render();
         }
-        // Append annotation list 
+        // Append annotation list
         this._navMenuContentElem.appendChild(annotationList.elem);
     }
 
@@ -54,10 +54,10 @@ function ToolbarView(controller, config){
         // Clear menu content
         this._drawToolElem.innerHTML = "";
 
-        // Render annotation tool if it's null 
+        // Render annotation tool if it's null
         annotationTool.render();
 
-        // Append annotation list 
+        // Append annotation list
         this._drawToolElem.appendChild(annotationTool.elem);
     }
 
@@ -71,11 +71,11 @@ function ToolbarView(controller, config){
 
         // Clear menu content
         this._navMenuContentElem.innerHTML = "";
-        // Render channel list if it's null 
+        // Render channel list if it's null
         if(channelList.elem == null){
             channelList.render();
         }
-        // Append annotation list 
+        // Append annotation list
         this._navMenuContentElem.appendChild(channelList.elem);
     }
 
@@ -92,10 +92,13 @@ function ToolbarView(controller, config){
         }
     }
 
-    // Toggle menu content 
+    // Toggle menu content
     this.toggleDisplayMenuContent = function(type, object){
-        
+
         this._navMenuContentElem.className = (this._navMenuContentElem.className.indexOf("expand") >= 0) ? "" : "expand";
+
+        // added to make sure the scroll is properly displayed
+        this._containerElem.className = (this._containerElem.className.indexOf("expand") >= 0) ? "" : "expand";
 
         // if it's expand, insert the content
         if(this._navMenuContentElem.className.indexOf("expand") >= 0){
@@ -114,12 +117,10 @@ function ToolbarView(controller, config){
 
     }
 
-    // Remove all the selected menu style from toolbar 
+    // Remove all the selected menu style from toolbar
     this.unselectMenuType = function(){
         this._navMenuElem.querySelectorAll(".menuType").forEach(function(elem){
             elem.className = "menuType";
         })
     }
 }
-
-

--- a/js/utils/util.js
+++ b/js/utils/util.js
@@ -99,95 +99,141 @@ Utils.prototype.getUrlContent = function(url){
     return res;
 }
 
-// Parsing browser's url to get file locations
-Utils.prototype.getParameters = function(){
-    var args = document.location.href.split("?"),
-        self = this,
-        type,
-        parameters = {};
+// given a url, return the query params object
+Utils.prototype.getQueryParams = function (url) {
+    var idx = url.lastIndexOf("?"), params = {};
+    var queries = url.slice(idx+1).split("&");
 
-    args = args[1] ? args[1].split("&") : [];
-    for(var i = 0; i < args.length; i++){
-        type = args[i].split("=")[0];
-        value = args[i].split("=")[1];
+    for (var i = 0; i < queries.length; i++) {
+        var q_parts = queries[i].split("=");
+        if (q_parts.length != 2) continue;
 
-        switch(type){
+        // NOTE: we're not decoding anything
+        var q_key = q_parts[0], q_val = q_parts[1];
+
+        if (!(q_key in params)) {
+            params[q_key] = [];
+        }
+
+        params[q_key].push(q_val);
+    }
+
+    return params;
+};
+
+// given the parameters object, process it
+Utils.prototype.processParams = function(inp){
+    var EMPTY = "null"; // this value should be ignored on all the attributes
+    var parameters = {}, self = this, paramKey, paramValue, value;
+
+    if (!inp) {
+        return parameters;
+    }
+
+    for (paramKey in inp) {
+        paramValue = inp[paramKey];
+
+        // TODO this could be improved,
+        // currently the params might be string or array
+        if (!Array.isArray(paramValue)) {
+            paramValue = [paramValue];
+        }
+
+        switch(paramKey){
             // array of urls
             case "url":
-                // Parameter.type are of 3 types : svg - for annotation overlay, iiif - files containing info.json and all the other file formats are treated as rest
-                // Note : SVG file could also used in other image types as well, needs to check the use case and modify in the future
-                // TODO the path of svg files are hardcoded and need to change
-                if(value.indexOf(".svg") != -1 || value.indexOf('resources/gene_expression/annotations') != -1){
-                    parameters.svgs = parameters.svgs || [];
-                    parameters.svgs.push(value);
-                }
-                else if(value.indexOf("ImageProperties.xml") != -1){
-                    parameters.images = parameters.images || [];
-                    parameters.images.push(value);
-                    parameters.type = 'dzi';
-                }
-                else if(value.indexOf("info.json") != -1) {
-                    parameters.images = parameters.images || [];
-                    parameters.images.push(value);
-                    parameters.type = 'iiif';
-                } else {
-                    parameters.images = parameters.images || [];
-                    parameters.images.push(value);
-                    parameters.type = 'rest';
-                }
+                paramValue.forEach(function (value) {
+                    // Parameter.type are of 3 types : svg - for annotation overlay, iiif - files containing info.json and all the other file formats are treated as rest
+                    // Note : SVG file could also used in other image types as well, needs to check the use case and modify in the future
+                    // TODO the path of svg files are hardcoded and need to change
+                    if(value.indexOf(".svg") != -1 || value.indexOf('resources/gene_expression/annotations') != -1){
+                        parameters.svgs = parameters.svgs || [];
+                        parameters.svgs.push(value);
+                    }
+                    else if(value.indexOf("ImageProperties.xml") != -1){
+                        parameters.images = parameters.images || [];
+                        parameters.images.push(value);
+                        parameters.type = 'dzi';
+                    }
+                    else if(value.indexOf("info.json") != -1) {
+                        parameters.images = parameters.images || [];
+                        parameters.images.push(value);
+                        parameters.type = 'iiif';
+                    } else if (value.length > 0 && value !== EMPTY) {
+                        parameters.images = parameters.images || [];
+                        parameters.images.push(value);
+                        parameters.type = 'rest';
+                    }
+                });
                 break;
             // array of string
             case "aliasName":
             case "channelName":
-                if( (value[0] == "\"" && value[value.length-1] == "\"") || (value[0] == "\'" && value[str.length-1] == "\'")){
-                    value = value.substr(1,value.length-2);
-                }
-                if(!parameters[type]){
-                    parameters[type] = [];
-                }
-                parameters[type].push(decodeURI(value));
+                paramValue.forEach(function (value) {
+                    if( (value[0] == "\"" && value[value.length-1] == "\"") || (value[0] == "\'" && value[str.length-1] == "\'")){
+                        value = value.substr(1,value.length-2);
+                    }
+                    if(!parameters[paramKey]){
+                        parameters[paramKey] = [];
+                    }
+                    parameters[paramKey].push(value.length > 0 && value !== EMPTY ? decodeURI(value) : null);
+                });
                 break;
             // array of boolean
             case "isRGB":
-                value = (value.toLocaleLowerCase() === "true") ? true : false;
-                if(!parameters[type]){
-                    parameters[type] = [];
-                }
-                parameters[type].push(value);
+                paramValue.forEach(function (value) {
+                    value = (value.toLocaleLowerCase() === "true") ? true : false;
+                    if(!parameters[paramKey]){
+                        parameters[paramKey] = [];
+                    }
+                    parameters[paramKey].push(value);
+                });
                 break;
             // array of color
             case "pseudoColor":
-                value = self.colorHexToRGB(decodeURI(value));
-                if(!parameters[type]){
-                    parameters[type] = [];
-                }
-                parameters[type].push(value);
+                paramValue.forEach(function (value) {
+                    value = self.colorHexToRGB(decodeURI(value));
+                    if(!parameters[paramKey]){
+                        parameters[paramKey] = [];
+                    }
+                    parameters[paramKey].push(value);
+                });
                 break;
             // string
             case "zoomLineThickness":
             case "waterMark":
+                value = paramValue[0];
+                if( (value[0] == "\"" && value[value.length-1] == "\"") || (value[0] == "\'" && value[str.length-1] == "\'")){
+                    value = value.substr(1,value.length-2);
+                }
+                if (value.length > 0 && value !== EMPTY) {
+                    parameters[paramKey] = decodeURI(value);
+                }
+                break;
             // float
             case "meterScaleInPixels":
             case "scale":
             case "x":
             case "y":
             case "z":
-                value = parseFloat(value);
+                value = parseFloat(paramValue[0]);
                 if(!isNaN(value)){
-                    parameters[type] = value;
+                    parameters[paramKey] = value;
                 }
                 break;
             // boolean
             case "ignoreReferencePoint":
             case "ignoreDimension":
             case "enableSVGStrokeWidth":
-                parameters[type] = (value.toLocaleLowerCase() === "true") ? true : false;
+                parameters[paramKey] = (paramValue[0].toLocaleLowerCase() === "true") ? true : false;
                 break;
             default:
-                console.log("unknown query parameter: " + args[i]);
+                console.log("unknown query parameter: " + paramKey);
         }
     }
-    // console.log(parameters);
+    console.log("------");
+    console.log("OSD viewer parameters: ", parameters);
+    console.log("------");
     return parameters;
 }
 

--- a/js/utils/util.js
+++ b/js/utils/util.js
@@ -139,6 +139,7 @@ Utils.prototype.getParameters = function(){
                 parameters[type] = decodeURI(value);
                 break;
             case "aliasName":
+            case "channelRGB":
             case "channelName":
                 if( (value[0] == "\"" && value[value.length-1] == "\"") || (value[0] == "\'" && value[str.length-1] == "\'")){
                     value = value.substr(1,value.length-2);

--- a/js/viewer/channel/channel.js
+++ b/js/viewer/channel/channel.js
@@ -28,23 +28,30 @@ function Channel(osdItemID, name, options) {
 
 
 Channel.prototype.colorMapping = {
+    // far red (magenta)
+    'Alexa Fluor 633': '1.000000 0.000000 1.000000',
+    'Alexa Fluor 647': '1.000000 0.000000 1.000000',
+
     // red
     'Rhodamine': '1.000000 0.000000 0.000000',
     'RFP': '1.000000 0.000000 0.000000',
     'Alexa Fluor 555': '1.000000 0.000000 0.000000',
     'Alexa Fluor 594': '1.000000 0.000000 0.000000',
     'tdTomato': '1.000000 0.000000 0.000000',
-    'Alexa Fluor 633': '1.000000 0.000000 0.000000',
-    'Alexa Fluor 647': '1.000000 1.000000 0.000000', // TODO customized based on demo image, should be reverted
+    'mcherry': '1.000000 0.000000 0.000000',
 
     //green
     'FITC': '0.000000 1.000000 0.000000',
     'Alexa 488': '0.000000 1.000000 0.000000',
     'EGFP': '0.000000 1.000000 0.000000',
-    'Alexa Fluor 488': '0.000000 1.000000 0.200000', // TODO customized based on demo image, should be reverted
+    'Alexa Fluor 488': '0.000000 1.000000 0.000000',
 
     //blue
-    'DAPI': '0.000000 0.000000 1.000000'
+    'DAPI': '0.000000 0.000000 1.000000',
+    'Hoechst': '0.000000 0.000000 1.000000',
+
+    // any uknown channel name will be mapped to this
+    'unknown': '1.000000 1.000000 1.000000'
 };
 
 Channel.prototype.getFiltersList = function () {
@@ -108,9 +115,10 @@ Channel.prototype.setDefaultHue = function () {
         this.hue = hueIs(this.rgb);
     } else {
       switch (this.name) {
-          case "unknown":
-              this.hue = 180;
-              break;
+          // TODO why?
+          // case "unknown":
+          //     this.hue = 180;
+          //     break;
           case "combo":
           case "TL Brightfield":
               this.hue = null;
@@ -118,6 +126,9 @@ Channel.prototype.setDefaultHue = function () {
           default:
               if (this.name in this.colorMapping) {
                   this.hue = hueIs(this.colorMapping[this.name]);
+              } else {
+                  // any unknown channel should be white
+                  this.hue = hueIs(this.colorMapping['unknown']);
               }
               break;
       }

--- a/js/viewer/channel/channel.js
+++ b/js/viewer/channel/channel.js
@@ -76,7 +76,7 @@ Channel.prototype.getFiltersList = function () {
     if (this.hue != null) {
         list.push(OpenSeadragon.Filters.HUE(this.hue));
     }
-    console.log("list", list);
+    // console.log("list", list);
     return list;
 }
 
@@ -148,9 +148,9 @@ Channel.prototype.setDefaultGamma = function () {
 
 
 Channel.prototype.set = function (type, value) {
-    console.log(
-      "channel set" , type, value
-    );
+    // console.log(
+    //   "channel set" , type, value
+    // );
     if (!type) { return }
 
     switch (type.toUpperCase()) {

--- a/js/viewer/channel/channel.js
+++ b/js/viewer/channel/channel.js
@@ -19,7 +19,11 @@ function Channel(osdItemID, name, options) {
       brightness: 0,
       gamma: 0.875,
       hue: null,
-    }
+    };
+
+    // we might want to offer hue control but not apply it by default.
+    // for example in case of a greyscale image with an unknown channelName
+    this.deactivateHue = false;
 
     // Set Default Values
     this.setDefaultHue();
@@ -73,9 +77,11 @@ Channel.prototype.getFiltersList = function () {
         list.push(OpenSeadragon.Filters.GAMMA(this.gamma));
     }
 
-    if (this.hue != null) {
+    // only apply hue if it's activated
+    if (this.hue != null && !this.deactivateHue) {
         list.push(OpenSeadragon.Filters.HUE(this.hue));
     }
+
     // console.log("list", list);
     return list;
 }
@@ -129,8 +135,11 @@ Channel.prototype.setDefaultHue = function () {
               if (this.name in this.colorMapping) {
                   this.hue = hueIs(this.colorMapping[this.name]);
               } else {
-                  // any unknown channel should be white
+                  // make sure hue has a default value
                   this.hue = hueIs(this.colorMapping['unknown']);
+
+                  // deactivate hue control
+                  this.deactivateHue = true;
               }
               break;
       }
@@ -165,6 +174,11 @@ Channel.prototype.set = function (type, value) {
             break;
         case "HUE":
             this.hue = value;
+            // activate the hue control so the value change takes effect
+            this.deactivateHue = false;
+            break;
+        case "DEACTIVATEHUE":
+            this.deactivateHue = true;
             break;
     }
  //    if(!resetMode)

--- a/js/viewer/channel/channel.js
+++ b/js/viewer/channel/channel.js
@@ -5,8 +5,8 @@ function Channel(osdItemID, name, options) {
     this.id = osdItemID;
     this.name = (typeof name === "string") ? name : "";
     this.name = this.name.replace(/\_/g, " ");
-
-    this.rgb = options["channelRGB"] || null;
+    this.isMultiColor = options['isRGB'] || false;
+    this.rgb = options["pseudoColor"] || null;
     this.opacity = options["channelAlpha"] || 1;;
     this.width = +options["width"] || 0;
     this.height = +options["height"] || 0;
@@ -106,19 +106,21 @@ function hueIs(rgb) { // Copied from old code  - need to how this works and when
     var _rgb=rgb.split(" ");
     var p=_rgb2hsl(parseFloat(_rgb[0]), parseFloat(_rgb[1]), parseFloat(_rgb[2]));
     var hue = p[0] * 360;
-    return hue;
+    return Math.round(hue);
 }
 
 Channel.prototype.setDefaultHue = function () {
-    if (this.rgb != null) {
-        // get hue from rgb value..
+    // don't offer any hue control
+    if (this.isMultiColor) {
+        this.hue = null;
+    }
+    // get hue from rgb value
+    else if (this.rgb != null) {
         this.hue = hueIs(this.rgb);
-    } else {
+    }
+    // find the color mapping based on the channel name
+    else {
       switch (this.name) {
-          // TODO why?
-          // case "unknown":
-          //     this.hue = 180;
-          //     break;
           case "combo":
           case "TL Brightfield":
               this.hue = null;

--- a/js/viewer/channel/channel.js
+++ b/js/viewer/channel/channel.js
@@ -178,7 +178,7 @@ Channel.prototype.set = function (type, value) {
             this.deactivateHue = false;
             break;
         case "DEACTIVATEHUE":
-            this.deactivateHue = true;
+            this.deactivateHue = (value === true);
             break;
     }
  //    if(!resetMode)

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -706,6 +706,7 @@ function Viewer(parent, config) {
                 brightness: channel["brightness"],
                 gamma: channel["gamma"],
                 hue : channel["hue"],
+                deactivateHue : channel['deactivateHue'],
                 osdItemId: channel["id"]
             });
 

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -643,9 +643,9 @@ function Viewer(parent, config) {
 
             // TODO what if there are no channel names?
             // The below code is for aliasName used in place of channelName
-            var channelName = Array.isArray(this.parameters.channelName) &&  this.parameters.channelName[i] ? this.parameters.channelName[i] : "";
-            if (this.parameters.aliasName && this.parameters.aliasName.length > i) {
-                channelName = this.parameters.aliasName[i];
+            var channelName = Array.isArray(params.channelName) &&  params.channelName[i] ? params.channelName[i] : "";
+            if (params.aliasName && params.aliasName[i]) {
+                channelName = params.aliasName[i];
             }
 
             // use the index for the channelName
@@ -681,10 +681,15 @@ function Viewer(parent, config) {
 
             // make sure the scale is properly defined
             meterScaleInPixels = options.meterScaleInPixels ? options.meterScaleInPixels : meterScaleInPixels;
-            meterScaleInPixels = this.parameters.meterScaleInPixels ? this.parameters.meterScaleInPixels : meterScaleInPixels;
+            meterScaleInPixels = params.meterScaleInPixels ? params.meterScaleInPixels : meterScaleInPixels;
             this.scale = (meterScaleInPixels != null) ? 1000000 / meterScaleInPixels : null;
 
             this.resetScalebar(meterScaleInPixels);
+
+            // channelRGB
+            if (Array.isArray(params.channelRGB) && params.channelRGB[i]) {
+                options.channelRGB = params.channelRGB[i];
+            }
 
             // add to the list of channels
             channel = new Channel(i, channelName, options);

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -37,7 +37,7 @@ function Viewer(parent, config) {
     this.svgFiles = {};
 
     // Init
-    this.init = function (utils) {
+    this.init = function (utils, params) {
 
         if (!OpenSeadragon || !utils) {
             return null;
@@ -45,7 +45,7 @@ function Viewer(parent, config) {
         this._utils = utils;
 
         // Add each image source into Openseadragon viewer
-        this.parameters = this._utils.getParameters();
+        this.parameters = this._utils.processParams(params);
 
         // Setting the config based on the type of the image we get
         this._config = this._utils.setOsdConfig(this.parameters, this.all_config);

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -143,7 +143,7 @@ function Viewer(parent, config) {
         tileSource.overlap = parseInt(xmlDoc.getAttribute("overlap")) || 0;
         tileSource.channelName = xmlDoc.getAttribute("channelName");
         tileSource.channelAlpha = +xmlDoc.getAttribute("channelDefaultAlpha");
-        tileSource.channelRGB = xmlDoc.getAttribute("channelDefaultRGB");
+        tileSource.pseudoColor = xmlDoc.getAttribute("channelDefaultRGB");
         tileSource.dir = xmlDoc.getAttribute("data");
         tileSource.format = xmlDoc.getAttribute("format") || "jpg";
         tileSource.meterScaleInPixels = parseFloat(xmlDoc.getAttribute("meterScaleInPixels"));
@@ -686,9 +686,14 @@ function Viewer(parent, config) {
 
             this.resetScalebar(meterScaleInPixels);
 
-            // channelRGB
-            if (Array.isArray(params.channelRGB) && params.channelRGB[i]) {
-                options.channelRGB = params.channelRGB[i];
+            // pseudoColor
+            if (Array.isArray(params.pseudoColor) && (typeof params.pseudoColor[i] === 'string')) {
+                options.pseudoColor = params.pseudoColor[i];
+            }
+
+            // isRGB
+            if (Array.isArray(params.isRGB) && (typeof params.isRGB[i] === 'boolean')) {
+                options.isRGB = params.isRGB[i];
             }
 
             // add to the list of channels

--- a/mview.html
+++ b/mview.html
@@ -24,6 +24,9 @@
             <div id="navMenuContent"></div>
         </div>
         <div id="drawToolContainer"></div>
+        <div id="openseadragonSpinner">
+            <i class="fa fa-spinner fa-pulse"></i>
+        </div>
         <div id="openseadragonContainer"></div>
     </div>
 

--- a/vendor/openseadragon.js
+++ b/vendor/openseadragon.js
@@ -21442,6 +21442,8 @@ function getTile(
  * @param {Number} time
  */
 function loadTile( tiledImage, tile, time ) {
+    // console.log("level=" + tile.level + ", x=" + tile.x + ", y=" + tile.y);
+    // console.log("url: ", tile.url);
     tile.loading = true;
     tiledImage._imageLoader.addJob({
         src: tile.url,


### PR DESCRIPTION
This PR will add the required changes for #49 dynamic configuration. Most of the changes directly related to this epic are done in [chaise#2027](https://github.com/informatics-isi-edu/chaise/pull/2027). Summary of changes done in OSD viewer:

- Add new `isRGB` and `pseudoColor` query parameters. If `isRGB=true`, we won't provide the hue control. And `pseudoColor` dictates the value of hue.
- Add a new message-passing configuration method. I didn't want to change the code that much, so while with the new change we can pass objects to OSD viewer, the objects have the same structure as query parameters. We could refactor this later and improve the quality of code related to this to pass proper objects.
- Add a new button that allows users to deactivate hue filter (show the image as is without any additional hue filter)
