### PR TITLE
add channel bulk controls + change default display of channels

### DIFF
--- a/css/toolbar/channel-item.css
+++ b/css/toolbar/channel-item.css
@@ -1,6 +1,6 @@
 #navMenuContent .groups .channelItem{
     /* border-bottom: 1px solid #cecece; */
-    padding: 10px 0;
+    padding: 5px 0;
     white-space: nowrap;
 }
 
@@ -44,6 +44,10 @@
 }
 
 #navMenuContent .groups .channelItem .toggleVisibility:hover{color: #fff;}
+
+#navMenuContent .groups .channelItem .toggleVisibility:active {
+    color: #4674A7;
+}
 
 #navMenuContent .groups .channelItem .setting{
     display: flex;
@@ -91,9 +95,13 @@
     border-radius: 2px;
     background: #a6a4a4;
     cursor: pointer;
-    font-family: "Font Awesome 5 Pro";
+    font-family: "Font Awesome 5 Free";
     font-weight: 900;
     position: relative;
+}
+
+#navMenuContent .groups .channelItem .deactivate-hue:hover {
+    color: #fff;
 }
 
 
@@ -104,11 +112,10 @@
 #navMenuContent .groups .channelItem .deactivate-hue.active:after {
     position: absolute;
     color: #4674A7;
-    top: 0;
+    top: -1px;
     left: 0;
     content: "\f00c";
-    font: normal normal normal 14px/1 FontAwesome;
-    font-size: 12px;
+    font-size: 11px;
 }
 
 

--- a/css/toolbar/channel-list.css
+++ b/css/toolbar/channel-list.css
@@ -6,28 +6,59 @@
     background: #2f2f2f;
     color: #c1c1c1;
     padding: 10px 0;
+    padding-bottom: 0;
 }
 
 
 #menuContainer #navMenuContent .channelList .title-container {
     display: flex;
     justify-content: space-between;
-    align-items: baseline;
+    align-items: center;
+}
+
+#menuContainer #navMenuContent .channelList .title-content {
+    display: flex;
+    align-items: center;
+}
+
+#menuContainer #navMenuContent .channelList .channels-control {
+    padding: 0 5px;
+    cursor: pointer;
+    font-size: 15px;
+}
+#menuContainer #navMenuContent .channelList .channels-control:active {
+    color: #4674A7 !important;
+}
+#menuContainer #navMenuContent .channelList .channels-control:hover{
+    color: #fff;
+}
+
+#menuContainer #navMenuContent .channelList .channels-control.fa-caret-up,
+#menuContainer #navMenuContent .channelList .channels-control.fa-caret-down {
+    font-size: 20px;
+}
+
+#menuContainer #navMenuContent .channelList hr.section-separator {
+    height: 1px;
+    border: 0;
+    border-top: 1px solid #5d5d5d;
+    margin: 5px 10px;
+    padding: 0;
 }
 
 #menuContainer #navMenuContent .channelList .title{
-    font-size: 14px;
+    font-size: 17px;
     font-weight: bold;
     color: #fff;
     text-align: left;
-    padding: 5px 10px 0;
+    padding: 5px 0;
 }
 
 #navMenuContent .channelList .groups{
     display: flex;
     flex-direction: column;
     box-sizing: border-box;
-    padding: 5px 10px 5px 10px;
+    padding: 0px 10px 5px 10px;
     flex: 1;
 }
 #navMenuContent .channelList .dismiss-channel {
@@ -35,4 +66,5 @@
   background-color:transparent;
   float:right !important;
   color: white;
+  font-size: 17px;
 }

--- a/js/config.js
+++ b/js/config.js
@@ -77,6 +77,7 @@ var _config = {
           }
         },
         constants: {
+          MAX_NUM_DEFAULT_CHANNEL: 5, // if there are more channels, they will be hidden by default.
           UNKNOWN_ANNNOTATION: 'UNKNOWN',
           STYLE_ATTRIBUTE_LIST: ['alignment-baseline', 'baseline-shift', 'clip', 'clip-path', 'clip-rule', 'color', 'color-interpolation', 'color-interpolation-filters', 'color-profile', 'color-rendering', 'cursor', 'direction', 'display', 'dominant-baseline', 'enable-background', 'fill', 'fill-opacity', 'fill-rule', 'filter', 'flood-color', 'flood-opacity', 'font-family', 'font-size', 'font-size-adjust', 'font-stretch', 'font-style', 'font-variant', 'font-weight', 'glyph-orientation-horizontal', 'glyph-orientation-vertical', 'image-rendering', 'kerning', 'letter-spacing', 'lighting-color', 'marker-end', 'marker-mid', 'marker-start', 'mask', 'opacity', 'overflow', 'pointer-events', 'shape-rendering', 'stop-color', 'stop-opacity', 'stroke', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'text-anchor', 'text-decoration', 'text-rendering', 'transform', 'transform-origin', 'unicode-bidi', 'vector-effect', 'visibility', 'word-spacing', 'writing-mode'],
           DEFAULT_SVG_STROKE_WIDTH: '1px',

--- a/js/toolbar/channel-item.js
+++ b/js/toolbar/channel-item.js
@@ -14,11 +14,10 @@ function ChannelItem(data){
 
     this.deactivateHue = data["deactivateHue"] || false;
 
-    this.opacity = data["opacity"] || "";
     this.osdItemId = data["osdItemId"];
     this.parent = data.parent || null;
-    this.isDisplay = true;
-    this.isExpand = true;
+    this.isDisplay = (typeof data["isDisplay"] === "boolean") ? data["isDisplay"] : true;
+    this.isExpand = (typeof data["isDisplay"] === "boolean") ? data["isDisplay"] : true;
     this.elem = null;
 
     this.getIconClass = function(type){
@@ -35,20 +34,28 @@ function ChannelItem(data){
     }
 
     // Click to expand/collapse the setting
-    this.onClickToggleExpand = function(){
-        _self.isExpand = !_self.isExpand;
+    this.onClickToggleExpand = function(expand){
+        if (typeof expand === "boolean") {
+            _self.isExpand = expand;
+        } else {
+            _self.isExpand = !_self.isExpand;
+        }
         _self.elem.querySelector(".setting").className = _self.isExpand ? "setting" : "setting collapse";
-        this.querySelector(".toggleSetting").innerHTML = "<i class='"+_self.getIconClass("expandPanel")+"'></i>";
+        _self.elem.querySelector(".toggleSetting").innerHTML = "<i class='"+_self.getIconClass("expandPanel")+"'></i>";
     };
 
     // Click to toggle overlay visibility
-    this.onClickToggleDisplay = function(event){
-        _self.isDisplay = !_self.isDisplay;
+    this.onClickToggleDisplay = function(event, isDisplay){
+        if (typeof isDisplay === "boolean") {
+            _self.isDisplay = isDisplay;
+        } else {
+            _self.isDisplay = !_self.isDisplay;
+        }
         _self.parent.dispatchEvent('changeOsdItemVisibility', {
             osdItemId : _self.osdItemId,
             isDisplay : _self.isDisplay
         })
-        this.innerHTML = "<i class='"+_self.getIconClass("toggleDisplay")+"'></i>";
+        _self.elem.querySelector(".toggleVisibility").innerHTML = "<i class='"+_self.getIconClass("toggleDisplay")+"'></i>";
         event.stopPropagation();
     };
 
@@ -145,7 +152,7 @@ function ChannelItem(data){
                 "<span class='channelName'>"+ this.name +"</span>",
                 "<span class='toggleVisibility' data-type='visibility'><i class='"+this.getIconClass("toggleDisplay")+"'></i></span>",
             "</div>",
-            "<div class='setting expand'>",
+            "<div class='setting" + (!this.isExpand ? " collapse" : "") + "'>",
                 "<span class='sliderContainer' data-type='contrast'>",
                     "<span class='attrRow'>",
                         "<span class='name'>Contrast</span>",

--- a/js/toolbar/channel-list.js
+++ b/js/toolbar/channel-list.js
@@ -1,4 +1,4 @@
-function ChannelList(parent){
+function ChannelList(parent) {
 
     var _self = this;
 
@@ -6,30 +6,31 @@ function ChannelList(parent){
     this.collection = {};
     this.parent = parent || null;
 
-    // Add new annotation items
-    this.add = function(items){
+    // Add new channel items
+    this.add = function(items) {
         var id,
             item,
             i;
 
-        for(i = 0; i < items.length; i++){
+        for (i = 0; i < items.length; i++) {
             id = items[i].osdItemId;
 
-            if(!this.collection.hasOwnProperty(id)){
+            if (!this.collection.hasOwnProperty(id)) {
                 item = new ChannelItem({
-                    name : items[i]["name"],
-                    contrast : items[i]["contrast"],
-                    brightness : items[i]["brightness"],
-                    gamma : items[i]["gamma"],
-                    hue : items[i]["hue"],
+                    name: items[i]["name"],
+                    contrast: items[i]["contrast"],
+                    brightness: items[i]["brightness"],
+                    gamma: items[i]["gamma"],
+                    hue: items[i]["hue"],
                     deactivateHue: items[i]["deactivateHue"],
-                    osdItemId : id,
-                    parent : _self
+                    osdItemId: id,
+                    isDisplay: items[i]["isDisplay"],
+                    parent: _self
                 });
 
                 this.collection[id] = item;
 
-                if(this.elem != null){
+                if (this.elem != null) {
                     item.render();
                     this.elem.querySelector(".groups").appendChild(item.elem);
                 };
@@ -37,40 +38,83 @@ function ChannelList(parent){
         }
     }
 
+    this.replaceList = function(items) {
+        this.collection = {};
+        this.add(items);
+    }
+
     // Dispatch the event to the parent
-    this.dispatchEvent = function(type, data){
+    this.dispatchEvent = function(type, data) {
         this.parent.dispatchEvent(type, data);
     }
 
     this.onClickedMenuHandler = function() {
-      _self.parent.onClickedMenuHandler("channelList")
-      _self.parent.dispatchEvent("hideChannelList");
+        _self.parent.onClickedMenuHandler("channelList")
+        _self.parent.dispatchEvent("hideChannelList");
     }
 
+    this.expandAllChannels = function (event) {
+        for (var id in _self.collection) {
+            _self.collection[id].onClickToggleExpand(true);
+        }
+    };
+
+    this.collapseAllChannels = function (event) {
+        for (var id in _self.collection) {
+            _self.collection[id].onClickToggleExpand(false);
+        }
+    };
+
+    this.showAllChannels = function (event) {
+        for (var id in _self.collection) {
+            _self.collection[id].onClickToggleDisplay(event, true);
+        }
+    };
+
+    this.hideAllChannels = function (event) {
+        for (var id in _self.collection) {
+            _self.collection[id].onClickToggleDisplay(event, false);
+        }
+    };
+
     // Render the view
-    this.render = function(){
+    this.render = function() {
 
         var id,
             collection = this.collection,
             listElem = document.createElement("div");
 
         listElem.setAttribute("class", "channelList");
-        if (collection,Object.keys(collection).length === 0 && collection.constructor === Object) {
-          listElem.innerHTML = [
-              "<div class='title-container'><span class='title'>Channels</span> <button class='dismiss-channel' title='dismiss'><i class='fa fa-times'></i></button></div>",
-              "<div class='groups'> No Channels found",
-              "</div>"
-          ].join("");
+        if (collection, Object.keys(collection).length === 0 && collection.constructor === Object) {
+            listElem.innerHTML = [
+                "<div class='title-container'>",
+                    "<button class='dismiss-channel' title='dismiss'><i class='fas fa-caret-left'></i></button>",
+                    "<span class='title'>Channels</span>",
+                "</div>",
+                "<hr class='section-separator'/>",
+                "<div class='groups'> No Channels found</div>"
+            ].join("");
         } else {
-          listElem.innerHTML = [
-              "<div class='title-container'><span class='title'>Channels</span> <button class='dismiss-channel' title='dismiss' style='border:none;background-color:transparent; float:right!important;'><i class='fa fa-times'></i></button></div>",
-              "<div class='groups'>",
-              "</div>"
-          ].join("");
+            listElem.innerHTML = [
+                "<div class='title-container'>",
+                    "<div class='title-content'>",
+                        "<button class='dismiss-channel' title='dismiss'><i class='fas fa-caret-left'></i></button>",
+                        "<span class='title'>Channels</span>",
+                    "</div>",
+                    "<div class='all-channel-controls'>",
+                        "<span title='Expand all channel controls' class='channels-control fa fa-caret-down' id='expand-all-channels'></span>",
+                        "<span title='Collapse all channel controls' class='channels-control fa fa-caret-up' id='collapse-all-channels'></span>",
+                        "<span title='Display all channels' class='channels-control fa fa-eye' id='show-all-channels'></span>",
+                        "<span title='Hide all channels' class='channels-control fa fa-eye-slash' id='hide-all-channels'></span>",
+                    "</div>",
+                "</div>",
+                "<hr class='section-separator'/>",
+                "<div class='groups'></div>"
+            ].join("");
         }
         // console.log("Collection are herre",  collection,Object.keys(collection).length === 0 && collection.constructor === Object);
-        for(id in collection){
-            if(collection[id].elem == null){
+        for (id in collection) {
+            if (collection[id].elem == null) {
                 collection[id].render();
             }
             listElem.querySelector(".groups").appendChild(collection[id].elem);
@@ -78,9 +122,17 @@ function ChannelList(parent){
 
         this.elem = listElem;
 
-        this.elem.querySelectorAll(".dismiss-channel").forEach(function(elem){
+        this.elem.querySelectorAll(".dismiss-channel").forEach(function(elem) {
             elem.addEventListener('click', this.onClickedMenuHandler);
         }.bind(this));
+
+        this.elem.querySelector('#expand-all-channels').addEventListener('click', this.expandAllChannels);
+
+        this.elem.querySelector('#collapse-all-channels').addEventListener('click', this.collapseAllChannels);
+
+        this.elem.querySelector('#show-all-channels').addEventListener('click', this.showAllChannels);
+
+        this.elem.querySelector('#hide-all-channels').addEventListener('click', this.hideAllChannels);
 
     }
 }

--- a/js/toolbar/toolbar.controller.js
+++ b/js/toolbar/toolbar.controller.js
@@ -1,5 +1,5 @@
 function ToolbarController(parent, config){
-    
+
     if(!config){ return null; };
 
     var _self = this;
@@ -31,7 +31,7 @@ function ToolbarController(parent, config){
             default:
                 this.parent.dispatchEvent(type, data);
                 break;
-            
+
         }
     }
 
@@ -40,10 +40,10 @@ function ToolbarController(parent, config){
 
         // Drawing mode
         var mode = data.mode.toUpperCase();
-        // Check if the svg id exists 
+        // Check if the svg id exists
         var svgID = data.svgID || "";
         var groupID = data.groupID || "";
-        
+
         if(svgID != "" && groupID != ""){
             if(mode == "ON"){
                 // Save drawing SVG ID and group ID
@@ -57,7 +57,7 @@ function ToolbarController(parent, config){
                     groupID : ""
                 });
                 this._toolbarView.removeAnnotationTool(this.annotationTool);
-            }  
+            }
         }
     }
 
@@ -79,7 +79,7 @@ function ToolbarController(parent, config){
     // Binding events when toolbar menu get clicked by the user
     this.onClickedMenuHandler = function(clickMenuType, data){
 
-        // Trigger event handler for different menu type 
+        // Trigger event handler for different menu type
         switch (clickMenuType) {
             case "channelList":
                 this._toolbarView.toggleDisplayMenuContent(clickMenuType, this.channelList);
@@ -103,7 +103,7 @@ function ToolbarController(parent, config){
 
     // update channel from viewer
     this.updateChannelList = function(data){
-        this.channelList.add(data);
+        this.channelList.replaceList(data);
     }
 
     // update current drawing svg Id if drawing mode is on
@@ -124,4 +124,3 @@ function ToolbarController(parent, config){
         }
     }
 }
-

--- a/js/viewer/channel/channel.js
+++ b/js/viewer/channel/channel.js
@@ -7,7 +7,6 @@ function Channel(osdItemID, name, options) {
     this.name = this.name.replace(/\_/g, " ");
     this.isMultiColor = options['isRGB'] || false;
     this.rgb = options["pseudoColor"] || null;
-    this.opacity = options["channelAlpha"] || 1;;
     this.width = +options["width"] || 0;
     this.height = +options["height"] || 0;
     this.contrast = 1;
@@ -20,6 +19,8 @@ function Channel(osdItemID, name, options) {
       gamma: 0.875,
       hue: null,
     };
+
+    this.isDisplay = (typeof options["isDisplay"] === "boolean") ? options["isDisplay"] : true;
 
     // we might want to offer hue control but not apply it by default.
     // for example in case of a greyscale image with an unknown channelName
@@ -197,4 +198,8 @@ Channel.prototype.set = function (type, value) {
  //           processors: plist
  //        });
  //    }
+}
+
+Channel.prototype.setIsDisplay = function (isDisplay) {
+    this.isDisplay = (isDisplay == true);
 }


### PR DESCRIPTION
This PR,
- adds show/hide all, collapse/expand all
- changes the default behavior to only show the first 5 channels

I also removed the notion of `opacity` from `channel.js` and `channel-item.js` as it was not used at all. We're going to set the opacity to 0 or 1 depending on whether we want to show the channel or not.

#56 