### PR TITLE
Empty annotation bug

### DIFF
--- a/js/viewer/annotation/annotation-group.js
+++ b/js/viewer/annotation/annotation-group.js
@@ -116,7 +116,7 @@ function AnnotationGroup(id, anatomy, description, parent){
         }
     }
 
-    // Get number of annotations
+    // Get number of annotations that have been drawn
     this.getNumOfAnnotations = function () {
         // only count the images that have been drawn
         var count = 0;

--- a/js/viewer/annotation/annotation-group.js
+++ b/js/viewer/annotation/annotation-group.js
@@ -117,8 +117,15 @@ function AnnotationGroup(id, anatomy, description, parent){
     }
 
     // Get number of annotations
-    this.getNumOfAnnotations = function(){
-        return this.annotations.length;
+    this.getNumOfAnnotations = function () {
+        // only count the images that have been drawn
+        var count = 0;
+        for (var i = 0; i < this.annotations.length; i++) {
+            if (this.annotations[i].isDrawing == false) {
+                count++;
+            }
+        }
+        return count;
     }
 
     this.getStrokeScale = function(){


### PR DESCRIPTION
The issue is due to `getNumOfAnnotations` function which is used to determine whether there are annotations present or not. As per the current implementation of the code, whenever a draw tool is clicked a new annotation object is created. This newly created object (even though empty) will be counted in `getNumOfAnnotations`, and hence the number returned would not be 0 and therefore no error is thrown when the `Save` button is clicked.

To throw the error `Please draw annotation on the image.` the condition is that the number of annotations should be 0.

To correct this I made the following corrections to the code. In `getNumOfAnnotations` function I am only counting those annotations that have been drawn, i.e. annotations for which `isDrawing` is `False`. This makes sure that the empty annotations are not counted, and therefore this function returns 0, even when one of the draw icon is clicked as mentioned in the issue.

This approach only fixes this particular bug and not the issue that the annotation object is created as soon as the draw icon is clicked (the right approach should be, adding the new object just before the draw event starts). Related to issue #26 