### PR TITLE
Annotation save bug

### DIFF
--- a/js/toolbar/annotation-tool.js
+++ b/js/toolbar/annotation-tool.js
@@ -129,6 +129,7 @@ function AnnotationTool(parent){
                     this.curSVGID = data.svgID;
                     break;
                 case "groupID":
+                    this.updateMode('CURSOR');
                     this.curGroupID = data.groupID;
                     break;
                 case "stroke":

--- a/js/viewer/annotation/annotation-group.js
+++ b/js/viewer/annotation/annotation-group.js
@@ -97,13 +97,20 @@ function AnnotationGroup(id, anatomy, description, parent){
 
         var rst = ["<g id='"+this.id+"'>"];
         var i;
+        var hasValidAnnotations = false;
         for(i = 0; i < this.annotations.length; i++){
             var content = this.annotations[i].exportToSVG();
+            if (content != "") {
+                hasValidAnnotations = true;
+            }
             rst.push(content);
         };
-
-        rst.push("</g>");
-        return rst.join("");
+        if (hasValidAnnotations) {
+            rst.push("</g>");
+            return rst.join("");
+        } else {
+            return "";
+        }
     }
 
     // Get box boundaries of the group

--- a/js/viewer/annotation/annotation-group.js
+++ b/js/viewer/annotation/annotation-group.js
@@ -105,10 +105,12 @@ function AnnotationGroup(id, anatomy, description, parent){
             }
             rst.push(content);
         };
+
         if (hasValidAnnotations) {
             rst.push("</g>");
             return rst.join("");
         } else {
+            // if no annotation (i.e. has no valid annotation) was added to the rst return empty string
             return "";
         }
     }

--- a/js/viewer/annotation/annotation-group.js
+++ b/js/viewer/annotation/annotation-group.js
@@ -95,24 +95,20 @@ function AnnotationGroup(id, anatomy, description, parent){
             return "";
         }
 
-        var rst = ["<g id='"+this.id+"'>"];
-        var i;
-        var hasValidAnnotations = false;
-        for(i = 0; i < this.annotations.length; i++){
-            var content = this.annotations[i].exportToSVG();
-            if (content != "") {
-                hasValidAnnotations = true;
-            }
-            rst.push(content);
-        };
+        var rst = [], content;
 
-        if (hasValidAnnotations) {
-            rst.push("</g>");
-            return rst.join("");
-        } else {
-            // if no annotation (i.e. has no valid annotation) was added to the rst return empty string
+        this.annotations.forEach(function (annot) {
+            content = annot.exportToSVG();
+            if (content != "") {
+                rst.push(content);
+            }
+        });
+
+        if (rst.length === 0) {
             return "";
         }
+
+        return "<g id='" + this.id + "'>" + rst.join("") + "</g>";
     }
 
     // Get box boundaries of the group

--- a/js/viewer/annotation/annotation-svg.js
+++ b/js/viewer/annotation/annotation-svg.js
@@ -248,22 +248,6 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
                 }
             }
         }
-        // return all group content if groupID is not provided
-        else{
-            // console.log('else exportToSVG')
-            for(groupID in this.groups){
-                svg += "<svg viewBox='"+this.getViewBox().join(" ")+"'  xmlns='http://www.w3.org/2000/svg'  xmlns:xlink='http://www.w3.org/1999/xlink'>";
-                svg += "<scale x='"+imgScaleX+"' y='"+imgScaleY+"'/>";
-                svg += this.groups[groupID].exportToSVG();
-                svg += "</svg>";
-
-                rst.push({
-                    groupID : groupID,
-                    svg : svg,
-                    stroke: this.groups[groupID].stroke
-                });
-            }
-        }
 
         return rst;
     }

--- a/js/viewer/annotation/annotation-svg.js
+++ b/js/viewer/annotation/annotation-svg.js
@@ -231,18 +231,30 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
         // return matched group SVG content only if groupID provided
         if(groupID){
             if(this.groups.hasOwnProperty(groupID)){
-                svg += "<svg viewBox='"+this.getViewBox().join(" ")+"' xmlns='http://www.w3.org/2000/svg'  xmlns:xlink='http://www.w3.org/1999/xlink'>";
-                svg += "<scale x='"+imgScaleX+"' y='"+imgScaleY+"'/>";
-                svg += this.groups[groupID].exportToSVG();
-                svg += "</svg>";
+                var innerSVG = this.groups[groupID].exportToSVG();
+                if (innerSVG != "") {
+                    svg += "<svg viewBox='" + this.getViewBox().join(" ") + "' xmlns='http://www.w3.org/2000/svg'  xmlns:xlink='http://www.w3.org/1999/xlink'>";
+                    svg += "<scale x='" + imgScaleX + "' y='" + imgScaleY + "'/>";
+                    svg += innerSVG;
+                    svg += "</svg>";
 
-                rst.push({
-                    svgID : this.id,
-                    groupID : groupID,
-                    numOfAnnotations : this.groups[groupID].getNumOfAnnotations(),
-                    svg : svg,
-                    stroke: this.groups[groupID].stroke
-                });
+                    rst.push({
+                        svgID: this.id,
+                        groupID: groupID,
+                        numOfAnnotations: this.groups[groupID].getNumOfAnnotations(),
+                        svg: svg,
+                        stroke: this.groups[groupID].stroke
+                    });
+                } else {
+                    console.log('no svg');
+                    rst.push({
+                        svgID: this.id,
+                        groupID: groupID,
+                        numOfAnnotations: 0,
+                        svg: "",
+                        stroke: this.groups[groupID].stroke
+                    });
+                }
             }
         }
         // return all group content if groupID is not provided

--- a/js/viewer/annotation/annotation-svg.js
+++ b/js/viewer/annotation/annotation-svg.js
@@ -245,20 +245,12 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
                         svg: svg,
                         stroke: this.groups[groupID].stroke
                     });
-                } else {
-                    console.log('no svg');
-                    rst.push({
-                        svgID: this.id,
-                        groupID: groupID,
-                        numOfAnnotations: 0,
-                        svg: "",
-                        stroke: this.groups[groupID].stroke
-                    });
                 }
             }
         }
         // return all group content if groupID is not provided
         else{
+            // console.log('else exportToSVG')
             for(groupID in this.groups){
                 svg += "<svg viewBox='"+this.getViewBox().join(" ")+"'  xmlns='http://www.w3.org/2000/svg'  xmlns:xlink='http://www.w3.org/1999/xlink'>";
                 svg += "<scale x='"+imgScaleX+"' y='"+imgScaleY+"'/>";

--- a/js/viewer/annotation/annotation-svg.js
+++ b/js/viewer/annotation/annotation-svg.js
@@ -233,6 +233,7 @@ function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePo
             if(this.groups.hasOwnProperty(groupID)){
                 var innerSVG = this.groups[groupID].exportToSVG();
                 if (innerSVG != "") {
+                    // if there is some content present in the innerSVG, only then add to rst, else return empty array.
                     svg += "<svg viewBox='" + this.getViewBox().join(" ") + "' xmlns='http://www.w3.org/2000/svg'  xmlns:xlink='http://www.w3.org/1999/xlink'>";
                     svg += "<scale x='" + imgScaleX + "' y='" + imgScaleY + "'/>";
                     svg += innerSVG;


### PR DESCRIPTION
Solution to #68 

Made changes to `exportToSVG` of `annotation-svg.js` and `annotation-group.js` to make sure that, when no valid content (i.e. empty string) is being returned from there children indicating that no annotation object is present, these function would also return empty string/array. Returning empty ensures that when the user clicks on `Save` before actually drawing any annotation, an error will show up.