### PR TITLE
Change how pseudoColor is used and stored

### DIFF
--- a/js/toolbar/channel-item.js
+++ b/js/toolbar/channel-item.js
@@ -413,7 +413,7 @@ function ChannelItem(data) {
 
         // create the data that will be saved
         var configConst = window.OSDViewer.constants.CHANNEL_CONFIG,
-            data = { channelNumber: _self.number, channelConfig: {}};
+            data = { channelNumber: _self.number, channelConfig: {} };
         data.channelConfig[configConst.BLACK_LEVEL] = _self.blackLevel;
         data.channelConfig[configConst.WHITE_LEVEL] = _self.whiteLevel;
         data.channelConfig[configConst.GAMMA] = _self.gamma;
@@ -422,8 +422,9 @@ function ChannelItem(data) {
             data.channelConfig[configConst.SATURATION] = _self.saturation;
             data.channelConfig[configConst.HUE] = _self.hue;
             data.channelConfig[configConst.DISPLAY_GREYSCALE] = _self.displayGreyscale;
-        }
 
+            data.pseudoColor =  OSDViewer.utils.getColorHexForHue(_self.hue);
+        }
 
         if (dontDispatch) {
             return data;

--- a/js/utils/alerts.js
+++ b/js/utils/alerts.js
@@ -3,7 +3,7 @@ function AlertService() {
 
     this.showPseudoColorAlert = function (channel) {
         // TODO should be moved to a strings.js
-        var message = "Given Pseudo Color (" + OSDViewer.utils.colorRGBToHex(channel.rgb) + ") for channel \"" + channel.name + "\" is invalid and therefore ignored.";
+        var message = "Given Pseudo Color (" + OSDViewer.utils.colorRGBToHex(channel.pseudoColor) + ") for channel \"" + channel.name + "\" is invalid and therefore ignored.";
 
         OSDViewer.dispatchEvent( "showAlert", { type: "warning", message: message })
     }

--- a/js/utils/util.js
+++ b/js/utils/util.js
@@ -412,6 +412,20 @@ Utils.prototype.hsv2rgb = function (h, s, v) {
     return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
 }
 
+/**
+ * Given a hue value, return the hex value represting its full color
+ * @param {number} hue
+ * @returns a string representing the hex color
+ */
+Utils.prototype.getColorHexForHue = function (hue) {
+    var res = this.hsv2rgb(hue,1,1);
+    function componentToHex(c) {
+        var hex = c.toString(16);
+        return hex.length == 1 ? "0" + hex : hex;
+    }
+    return "#" + componentToHex(res[0]) + componentToHex(res[1]) + componentToHex(res[2]);
+};
+
 // Detect user's browser
 Utils.prototype.getUserBrowserType = function(){
 
@@ -581,7 +595,7 @@ ChannelNamesOverlayUtils.prototype.getUpdatedChannelNameForCanvas = function (ch
 }
 
 /**
- * This function returns the updated channel name, 
+ * This function returns the updated channel name,
  * i.e. if the channel name wont fit in a single line, it add ...
  * @param {String} channelName
  * @param {Int} containerWidth
@@ -598,7 +612,7 @@ ChannelNamesOverlayUtils.prototype.getUpdatedChannelNameForCanvas = function (ch
     }
 
     for (let i = channelName.length - 1; i >= 0; i--) {
-        
+
         // starrt removing chnaraters from the right one at a time, until the name would fit
         if (utils.getTextWidth(channelName.slice(0, i) + '...', font) + 40 < containerWidth * constants.USABLE_AREA) {
             // return the updated name
@@ -608,9 +622,9 @@ ChannelNamesOverlayUtils.prototype.getUpdatedChannelNameForCanvas = function (ch
 }
 
 /**
- * This function returns the font size which will be used in the screenshot. 
+ * This function returns the font size which will be used in the screenshot.
  * We start with font 20 and reduce it by 2 until the channel data can fit into the canvas. The min font size is 14.
- * 
+ *
  * TODO could potentially be merged with the other function used for overlay
  * @param {canvas context} ctx
  * @param {Array} channelData


### PR DESCRIPTION
For more information about why we decided to do these changes please refer to [this PR in chaise](https://github.com/informatics-isi-edu/chaise/pull/2177).

This PR will,
- Ensure `pseudoColor` is used even if the `ChannelConfig.hue` is defined.
- Send `pseudoColor` with other `ChannelConfig` values so Chaise can store it (Generated based on hue value).
- Rename `Channel.rgb` to `Channel.pseudoColor` to avoid introducing a new name for the same property.