### PR TITLE
Added arrowline annotation tool

### DIFF
--- a/js/toolbar/annotation-tool.js
+++ b/js/toolbar/annotation-tool.js
@@ -1,209 +1,220 @@
-function AnnotationTool(parent){
+function AnnotationTool(parent) {
+  var _self = this;
 
-    var _self = this;
+  this.elem = null;
+  this.parent = parent || null;
+  this.isDisplay = false;
+  this.curType = "CURSOR";
+  this.curSVGID = "";
+  this.curGroupID = "";
+  this.curStroke = "#f00000";
 
-    this.elem = null;
-    this.parent = parent || null;
-    this.isDisplay = false;
-    this.curType = 'CURSOR';
-    this.curSVGID = '';
-    this.curGroupID = '';
-    this.curStroke = '#f00000';
+  // Dispatch the event to the parent
+  this.dispatchEvent = function (type, data) {
+    switch (type) {
+      default:
+        this.parent.dispatchEvent(type, data);
+        break;
+    }
+  };
 
-    // Dispatch the event to the parent
-    this.dispatchEvent = function(type, data){
-        switch(type){
-            default:
-                this.parent.dispatchEvent(type, data);
-                break;
-        }
+  // Click to change annotation button
+  this.onClickChangeBtn = function () {
+    var btnType = this.getAttribute("data-type") || "";
+
+    if (btnType == "HELP") {
+      _self.dispatchEvent("openDrawingHelpPage");
+      return;
     }
 
-    // Click to change annotation button
-    this.onClickChangeBtn = function(){
-        var btnType = this.getAttribute("data-type") || "";
-
-        if (btnType == "HELP") {
-            _self.dispatchEvent('openDrawingHelpPage');
-            return;
-        }
-
-        if(_self.curType == btnType){
-            if (btnType == 'CURSOR') {
-                // we dont want to do anything if the cursor is clicked again
-                return;
-            }
-            btnType = 'CURSOR';
-        }
-
-        _self.dispatchEvent("drawingStop");
-        _self.updateMode(btnType);
-
+    if (_self.curType == btnType) {
+      if (btnType == "CURSOR") {
+        // we dont want to do anything if the cursor is clicked again
+        return;
+      }
+      btnType = "CURSOR";
     }
 
-    // Change stroke color. This function handles the flow when the color (stroke) is changed while drawing/editting the SVG.
-    this.onChangeStrokeColor = function(){
-        _self.curStroke = this.value;
-        _self.dispatchEvent("drawingStrokeChanged", {
-            svgID: _self.curSVGID,
-            groupID: _self.curGroupID,
-            type: _self.curType,
-            attrs: {
-                "stroke": _self.curStroke,
-                "fill": "None"
-            }
+    _self.dispatchEvent("drawingStop");
+    _self.updateMode(btnType);
+  };
+
+  // Change stroke color. This function handles the flow when the color (stroke) is changed while drawing/editting the SVG.
+  this.onChangeStrokeColor = function () {
+    _self.curStroke = this.value;
+    _self.dispatchEvent("drawingStrokeChanged", {
+      svgID: _self.curSVGID,
+      groupID: _self.curGroupID,
+      type: _self.curType,
+      attrs: {
+        stroke: _self.curStroke,
+        fill: "None",
+      },
+    });
+  };
+
+  // Render the view
+  this.render = function (data) {
+    var toolElem = null,
+      colorInput = null;
+    _self = this;
+
+    if (!this.elem) {
+      toolElem = document.createElement("div");
+      toolElem.setAttribute("class", "annotationTool flex-col");
+      toolElem.innerHTML = [
+        "<span class='toolBtn' data-type='CURSOR' data-toggle='tooltip' data-placement='right' title='Tooltip on right'>",
+        "<i class='fa fa-mouse-pointer'></i>",
+        "</span>",
+        "<span class='toolBtn' data-type='CHANGE_COLOR' title='Change Color'>",
+        "<input type='color' value='" +
+          _self.curStroke +
+          "' id='strokeColor'/>",
+        "</span>",
+        "<span class='toolBtn' data-type='PATH' title='Draw path'>",
+        "<i class='fas fa-pencil-alt'></i>",
+        "</span>",
+        "<span class='toolBtn' data-type='RECT' title='Draw rectangle'>",
+        "<i class='fa fa-square'></i>",
+        "</span>",
+        "<span class='toolBtn' data-type='CIRCLE' title='Draw circle'>",
+        "<i class='fa fa-circle'></i>",
+        "</span>",
+        "<span class='toolBtn' data-type='LINE' title='Draw line'>",
+        "<i class='fa fa-minus'></i>",
+        "</span>",
+        "<span class='toolBtn' data-type='ARROWLINE' title='Draw arrow line'>",
+        "<i class='fas fa-long-arrow-alt-right'></i>",
+        "</span>",
+        "<span class='toolBtn' data-type='POLYGON' title='Draw polygon'>",
+        "<i class='fas fa-draw-polygon'></i>",
+        "</span>",
+        "<span class='toolBtn' data-type='ERASER' title='Erase drawing'>",
+        "<i class='fa fa-eraser'></i>",
+        "</span>",
+        "<span class='toolBtn' data-type='HELP' title='Learn how to annotate an image'>",
+        "<i class='fas fa-question-circle'></i></a>",
+        "</span>",
+        // "<span class='toolBtn' data-type='SAVE'>",
+        //     "<i class='fa fa-floppy-o'></i>",
+        // "</span>"
+      ].join("");
+
+      toolElem.querySelector(
+        ".toolBtn[data-type='" + this.curType + "']"
+      ).className = "toolBtn selected";
+      this.elem = toolElem;
+
+      // Binding events
+      this.elem.querySelectorAll(".toolBtn").forEach(
+        function (elem) {
+          elem.addEventListener("click", this.onClickChangeBtn);
+        }.bind(this)
+      );
+
+      colorInput = this.elem.querySelector("#strokeColor");
+      colorInput.addEventListener("change", this.onChangeStrokeColor);
+    } else {
+      colorInput = this.elem.querySelector("#strokeColor");
+      // if a user changes the value, setAttribute doesn't work properly,
+      // so we have to use .value here
+      colorInput.value = this.curStroke;
+      this.elem.querySelectorAll(".toolBtn").forEach(function (elem) {
+        elem.className =
+          elem.getAttribute("data-type") === _self.curType
+            ? "toolBtn selected"
+            : "toolBtn";
+      });
+    }
+  };
+
+  // Update the drawing info
+  this.updateDrawInfo = function (data) {
+    for (var key in data) {
+      switch (key) {
+        case "svgID":
+          this.curSVGID = data.svgID;
+          break;
+        case "groupID":
+          this.updateMode("CURSOR");
+          this.curGroupID = data.groupID;
+          break;
+        case "stroke":
+          if (data.stroke && typeof data.stroke === "string") {
+            // the given color might not be understandable by input,
+            // so we have to change it into hex instead
+            var ctx = document.createElement("canvas").getContext("2d");
+            ctx.fillStyle = data.stroke;
+
+            // get the computed value
+            this.curStroke = ctx.fillStyle;
+          }
+          break;
+        case "type":
+          this.curType = data.type ? data.type : "CURSOR";
+          this.updateMode(this.curType);
+          break;
+      }
+    }
+  };
+
+  // Update the current mode
+  this.updateMode = function (mode) {
+    if (!_self.elem) {
+      return;
+    }
+
+    _self.elem.querySelector(
+      ".toolBtn[data-type='" + _self.curType + "']"
+    ).className = "toolBtn";
+    _self.curType = mode || "CURSOR";
+    _self.elem.querySelector(
+      ".toolBtn[data-type='" + _self.curType + "']"
+    ).className = "toolBtn selected";
+    switch (_self.curType) {
+      case "CURSOR":
+        _self.dispatchEvent("setMode", {
+          mode: "VIEW",
         });
+        break;
+      case "PATH":
+      case "CIRCLE":
+      case "RECT":
+      case "LINE":
+      case "ARROWLINE":
+      case "POLYGON":
+        _self.dispatchEvent("drawingStart", {
+          svgID: _self.curSVGID,
+          groupID: _self.curGroupID,
+          type: _self.curType,
+          attrs: {
+            stroke: _self.curStroke,
+            fill: "None",
+          },
+        });
+        break;
+      case "ERASER":
+        _self.dispatchEvent("setMode", {
+          mode: "ERASE_ANNOTATIONS",
+        });
+        break;
+      case "SAVE":
+        _self.dispatchEvent("saveAnatomySVG", {
+          svgID: _self.curSVGID,
+          groupID: _self.curGroupID,
+        });
+        break;
+      default:
+        break;
     }
+  };
 
-    // Render the view
-    this.render = function(data){
-
-        var toolElem = null,
-            colorInput = null;
-            _self = this;
-
-        if(!this.elem){
-            toolElem = document.createElement("div");
-            toolElem.setAttribute("class", "annotationTool flex-col");
-            toolElem.innerHTML = [
-                "<span class='toolBtn' data-type='CURSOR' data-toggle='tooltip' data-placement='right' title='Tooltip on right'>",
-                    "<i class='fa fa-mouse-pointer'></i>",
-                "</span>",
-                "<span class='toolBtn' data-type='CHANGE_COLOR' title='Change Color'>",
-                    "<input type='color' value='" + _self.curStroke + "' id='strokeColor'/>",
-                "</span>",
-                "<span class='toolBtn' data-type='PATH' title='Draw path'>",
-                    "<i class='fas fa-pencil-alt'></i>",
-                "</span>",
-                "<span class='toolBtn' data-type='RECT' title='Draw rectangle'>",
-                    "<i class='fa fa-square'></i>",
-                "</span>",
-                "<span class='toolBtn' data-type='CIRCLE' title='Draw circle'>",
-                    "<i class='fa fa-circle'></i>",
-                "</span>",
-                "<span class='toolBtn' data-type='LINE' title='Draw line'>",
-                    "<i class='fa fa-minus'></i>",
-                "</span>",
-                "<span class='toolBtn' data-type='POLYGON' title='Draw polygon'>",
-                    "<i class='fas fa-draw-polygon'></i>",
-                "</span>",
-                "<span class='toolBtn' data-type='ERASER' title='Erase drawing'>",
-                    "<i class='fa fa-eraser'></i>",
-                "</span>",
-                "<span class='toolBtn' data-type='HELP' title='Learn how to annotate an image'>",
-                    "<i class='fas fa-question-circle'></i></a>",
-                "</span>"
-                // "<span class='toolBtn' data-type='SAVE'>",
-                //     "<i class='fa fa-floppy-o'></i>",
-                // "</span>"
-            ].join("");
-
-            toolElem.querySelector(".toolBtn[data-type='"+this.curType+"']").className = "toolBtn selected";
-            this.elem = toolElem;
-
-            // Binding events
-            this.elem.querySelectorAll(".toolBtn").forEach(function(elem){
-                elem.addEventListener('click', this.onClickChangeBtn);
-            }.bind(this));
-
-            colorInput = this.elem.querySelector("#strokeColor");
-            colorInput.addEventListener('change', this.onChangeStrokeColor);
-        }
-        else{
-            colorInput = this.elem.querySelector("#strokeColor");
-            // if a user changes the value, setAttribute doesn't work properly,
-            // so we have to use .value here
-            colorInput.value = this.curStroke;
-            this.elem.querySelectorAll(".toolBtn").forEach(function(elem){
-                elem.className = (elem.getAttribute("data-type") === _self.curType) ?  "toolBtn selected" : "toolBtn";
-            });
-        }
-
-    }
-
-    // Update the drawing info
-    this.updateDrawInfo = function(data){
-        for (var key in data){
-            switch(key){
-                case "svgID":
-                    this.curSVGID = data.svgID;
-                    break;
-                case "groupID":
-                    this.updateMode('CURSOR');
-                    this.curGroupID = data.groupID;
-                    break;
-                case "stroke":
-                    if (data.stroke && typeof data.stroke === "string") {
-                        // the given color might not be understandable by input,
-                        // so we have to change it into hex instead
-                        var ctx = document.createElement("canvas").getContext("2d");
-                        ctx.fillStyle = data.stroke;
-
-                        // get the computed value
-                        this.curStroke = ctx.fillStyle;
-                    }
-                    break;
-                case "type":
-                    this.curType = data.type ? data.type : "CURSOR";
-                    this.updateMode(this.curType);
-                    break;
-            }
-        }
-    }
-
-    // Update the current mode
-    this.updateMode = function(mode){
-
-        if(!_self.elem){
-            return;
-        }
-
-        _self.elem.querySelector(".toolBtn[data-type='"+_self.curType+"']").className = "toolBtn";
-        _self.curType = mode || 'CURSOR';
-        _self.elem.querySelector(".toolBtn[data-type='"+_self.curType+"']").className = "toolBtn selected";
-        switch(_self.curType){
-            case "CURSOR":
-                _self.dispatchEvent("setMode", {
-                    mode : "VIEW"
-                });
-                break;
-            case "PATH":
-            case "CIRCLE":
-            case "RECT":
-            case "LINE":
-            case "POLYGON":
-                _self.dispatchEvent("drawingStart", {
-                    svgID : _self.curSVGID,
-                    groupID : _self.curGroupID,
-                    type : _self.curType,
-                    attrs : {
-                        "stroke" : _self.curStroke,
-                        "fill" : "None"
-                    }
-                });
-                break;
-            case "ERASER":
-                _self.dispatchEvent("setMode", {
-                    mode : "ERASE_ANNOTATIONS"
-                });
-                break;
-            case "SAVE":
-                _self.dispatchEvent("saveAnatomySVG", {
-                    svgID : _self.curSVGID,
-                    groupID : _self.curGroupID,
-                });
-                break;
-            default:
-                break;
-        }
+  // Get current drawing SVG Id and Group ID
+  this.getDrawInfo = function () {
+    return {
+      svgID: this.curSVGID,
+      groupID: this.curGroupID,
+      stroke: this.curStroke,
     };
-
-    // Get current drawing SVG Id and Group ID
-    this.getDrawInfo = function(){
-        return {
-            svgID : this.curSVGID,
-            groupID : this.curGroupID,
-            stroke : this.curStroke
-        }
-    }
+  };
 }

--- a/js/viewer/annotation/annotation-group.js
+++ b/js/viewer/annotation/annotation-group.js
@@ -1,275 +1,273 @@
-function AnnotationGroup(id, anatomy, description, parent){
-    var _self = this;
-    this.id = id || -1;
-    this.description = description || "no description";
-    this.anatomy = anatomy || "Unknown Anatomy";
-    this.annotations = [];
-    this.parent = parent;
+function AnnotationGroup(id, anatomy, description, parent) {
+  var _self = this;
+  this.id = id || -1;
+  this.description = description || "no description";
+  this.anatomy = anatomy || "Unknown Anatomy";
+  this.annotations = [];
+  this.parent = parent;
 
-    // Top-left diagonal point
-    this.x1 = null;
-    this.y1 = null;
-    // Bottom-right diagonal point
-    this.x2 = null;
-    this.y2 = null;
-    // svg elem
-    this.svg = null;
-    this.isDisplay = true;
-    this.isSelected = false;
+  // Top-left diagonal point
+  this.x1 = null;
+  this.y1 = null;
+  // Bottom-right diagonal point
+  this.x2 = null;
+  this.y2 = null;
+  // svg elem
+  this.svg = null;
+  this.isDisplay = true;
+  this.isSelected = false;
 
-    // the stroke that is used by annotations in this group
-    this.stroke = [];
+  // the stroke that is used by annotations in this group
+  this.stroke = [];
 
-    // Add new annotation object (path/cirlce/rect)
-    this.addAnnotation = function(type){
-        var annotation = null;
-        var graphID = Date.parse(new Date()) + parseInt(Math.random() * 10000);
-        var attrs = {
-            "graph-id" : graphID,
-            // "annotation-id" : this.id,
-            "parent" : this
-        }
-        switch (type.toUpperCase()) {
-            case "PATH":
-                annotation = new Path(attrs);
-                break;
-            case "POLYLINE":
-                annotation = new Polyline(attrs);
-                break;
-            case "POLYGON":
-                annotation = new Polygon(attrs);
-                break;
-            case "RECT":
-                annotation = new Rect(attrs);
-                break;
-            case "CIRCLE":
-                annotation = new Circle(attrs);
-                break;
-            case "LINE":
-                annotation = new Line(attrs);
-                break;
-        };
-
-        if(annotation != null){
-            this.annotations.push(annotation);
-        }
-
-        return annotation;
-    }
-
-    // Dispatch the event to the parent
-    this.dispatchEvent = function(type, data){
-
-        switch(type){
-            case "onClickChangeSelectingAnnotation":
-                data["groupID"] = this.id;
-                this.parent.dispatchEvent(type, data);
-                break;
-            case "onMouseoverShowTooltip":
-                data["anatomy"] = this.anatomy;
-                data["description"] = this.description;
-                data["x1"] = this.x1;
-                data["y1"] = this.y1;
-                data["x2"] = this.x2;
-                data["y2"] = this.y2;
-                data["groupID"] = this.id;
-                this.highlightAll();
-                this.parent.dispatchEvent(type, data);
-                break;
-            case "onMouseoutHideTooltip":
-                if(!this.isSelected){
-                    this.unHighlightAll();
-                }
-                this.parent.dispatchEvent(type, data);
-                break;
-            default:
-                this.parent.dispatchEvent(type, data);
-                break;
-        }
-    }
-
-    // Export group content
-    this.exportToSVG = function(){
-
-        if(this.annotations.length === 0){
-            return "";
-        }
-
-        var rst = [], content;
-
-        this.annotations.forEach(function (annot) {
-            content = annot.exportToSVG();
-            if (content != "") {
-                rst.push(content);
-            }
-        });
-
-        if (rst.length === 0) {
-            return "";
-        }
-
-        return "<g id='" + this.id + "'>" + rst.join("") + "</g>";
-    }
-
-    // Get box boundaries of the group
-    this.getBoxBoundaries = function(){
-        return {
-            x1 : this.x1,
-            y1 : this.y1,
-            x2 : this.x2,
-            y2 : this.y2
-        }
-    }
-
-    // Get number of annotations
-    this.getNumOfAnnotations = function(){
-        return this.annotations.length;
-    }
-
-    this.getStrokeScale = function(){
-        return this.parent.getStrokeScale();
-    }
-
-    // Highlight annotation objects
-    this.highlightAll = function(event){
-        var strokeScale = this.getStrokeScale() || 1;
-        var strokeWidth = 1;
-
-        _self.annotations.forEach(function(annotation){
-            strokeWidth = parseFloat(annotation._attrs["stroke-width"]) || 1;
-            strokeWidth =  strokeWidth * strokeScale * 2 || 5;
-            annotation.highlight({
-                "stroke-width" : strokeWidth === 0 ? 5 : strokeWidth,
-                // "stroke" : "yellow",
-            });
-        })
-    }
-
-    // Render a g container to contain annotation objects
-    this.render = function(){
-
-        var svg = d3.select(this.parent.svg)
-            .append("g")
-            .attr("id", this.id);
-
-        this.svg = svg;
-
-    }
-
-    // Remove an annotation by graphID
-    this.removeAnnotationByID = function(graphID){
-        var index;
-        var annotation = this.annotations.find(function(graph, i){
-            if(graph.id ==  graphID){
-                index = i;
-                return true;
-            }
-        })
-
-        if(!annotation){
-            return
-        }
-
-        // remove annotation object from the collection
-        this.annotations.splice(index, 1);
-
-        // remove event handlers for the annotation
-        annotation.unbind();
-
-        // remove svg element
-        annotation.svg.remove();
-    }
-
-    // Remove all annotations
-    this.removeAllAnnotations = function(){
-        this.annotations.forEach(function (annotation) {
-            // remove event handlers for the annotation
-            annotation.unbind();
-
-            // remove svg element
-            annotation.svg.remove();
-        });
-
-        // remove from the collection
-        this.annotations = [];
-    }
-
-    this.setAttributesByJSON = function(attrs){
-        var attr,
-            value;
-
-        for(attr in attrs){
-            value = attrs[attr];
-            switch(attr){
-                case "description":
-                case "anatomy":
-                    this[attr] = value;
-                    break;
-            }
-        }
-    }
-
-    this.setDisplay = function(isDisplay){
-        var displayStyle = (isDisplay) ? "block" : "none";
-        this.isDisplay = isDisplay;
-        this.svg.attr("display", displayStyle);
-    }
-
-    this.updateDiagonalPoints = function(){
-
-        // Set the annotation group boundaries based on the annotation
-        for(var i = 0; i < this.annotations.length; i++){
-            var annotation = this.annotations[i];
-            var bbox = annotation.svg.node().getBBox();
-            this.x1 = (this.x1 == null || bbox.x < this.x1) ? bbox.x : this.x1;
-            this.y1 = (this.y1 == null || bbox.y < this.y1) ? bbox.y : this.y1;
-            this.x2 = (bbox.x + bbox.width > this.x2) ? bbox.x + bbox.width : this.x2;
-            this.y2 = (bbox.y + bbox.height > this.y2) ? bbox.y + bbox.height : this.y2;
-        }
-    }
-
-    this.updateStrokeWidth = function(){
-        _self.annotations.forEach(function(annotation){
-            annotation.renderSVG();
-        })
-    }
-
-    /**
-     * Given an annotation, will update the this.stroke Array
-     * @param {Base} annot
-     */
-    this.setGroupStrokeByAnnotation = function (annot) {
-        var stroke = _self.parent.parent._utils.standardizeColor(annot._attrs.stroke);
-
-        if (_self.stroke.indexOf(stroke) === -1) {
-            _self.stroke.push(stroke);
-        }
+  // Add new annotation object (path/cirlce/rect)
+  this.addAnnotation = function (type) {
+    var annotation = null;
+    var graphID = Date.parse(new Date()) + parseInt(Math.random() * 10000);
+    var attrs = {
+      "graph-id": graphID,
+      // "annotation-id" : this.id,
+      parent: this,
     };
-
-    /**
-    * This function changes the color(stroke) of the each annotation to the new value passed as param
-    * @param {string} stroke the RGB value of the new color
-    */
-    this.updateStroke = function(stroke) {
-        var stroke = _self.parent.parent._utils.standardizeColor(stroke);
-
-        _self.stroke = [stroke];
-        _self.annotations.forEach(function (annotation) {
-            annotation._attrs.stroke = stroke;
-            // render the SVG after changing the color so that the new color is reflected in the viewer
-            annotation.renderSVG();
-        });
+    switch (type.toUpperCase()) {
+      case "PATH":
+        annotation = new Path(attrs);
+        break;
+      case "POLYLINE":
+        annotation = new Polyline(attrs);
+        break;
+      case "POLYGON":
+        annotation = new Polygon(attrs);
+        break;
+      case "RECT":
+        annotation = new Rect(attrs);
+        break;
+      case "CIRCLE":
+        annotation = new Circle(attrs);
+        break;
+      case "LINE":
+        annotation = new Line(attrs);
+        break;
+      case "ARROWLINE":
+        annotation = new ArrowLine(attrs);
+        break;
     }
 
-    this.updateInfo = function(data){
-        this.id = data.id;
-        this.anatomy = data.anatomy;
-        this.svg.attr("id", this.id);
+    if (annotation != null) {
+      this.annotations.push(annotation);
     }
 
-    this.unHighlightAll = function(){
-        _self.annotations.forEach(function(annotation){
-            annotation.unHighlight();
-        })
+    return annotation;
+  };
+
+  // Dispatch the event to the parent
+  this.dispatchEvent = function (type, data) {
+    switch (type) {
+      case "onClickChangeSelectingAnnotation":
+        data["groupID"] = this.id;
+        this.parent.dispatchEvent(type, data);
+        break;
+      case "onMouseoverShowTooltip":
+        data["anatomy"] = this.anatomy;
+        data["description"] = this.description;
+        data["x1"] = this.x1;
+        data["y1"] = this.y1;
+        data["x2"] = this.x2;
+        data["y2"] = this.y2;
+        data["groupID"] = this.id;
+        this.highlightAll();
+        this.parent.dispatchEvent(type, data);
+        break;
+      case "onMouseoutHideTooltip":
+        if (!this.isSelected) {
+          this.unHighlightAll();
+        }
+        this.parent.dispatchEvent(type, data);
+        break;
+      default:
+        this.parent.dispatchEvent(type, data);
+        break;
     }
+  };
+
+  // Export group content
+  this.exportToSVG = function () {
+    if (this.annotations.length === 0) {
+      return "";
+    }
+
+    var rst = [],
+      content;
+
+    this.annotations.forEach(function (annot) {
+      content = annot.exportToSVG();
+      if (content != "") {
+        rst.push(content);
+      }
+    });
+
+    if (rst.length === 0) {
+      return "";
+    }
+
+    return "<g id='" + this.id + "'>" + rst.join("") + "</g>";
+  };
+
+  // Get box boundaries of the group
+  this.getBoxBoundaries = function () {
+    return {
+      x1: this.x1,
+      y1: this.y1,
+      x2: this.x2,
+      y2: this.y2,
+    };
+  };
+
+  // Get number of annotations
+  this.getNumOfAnnotations = function () {
+    return this.annotations.length;
+  };
+
+  this.getStrokeScale = function () {
+    return this.parent.getStrokeScale();
+  };
+
+  // Highlight annotation objects
+  this.highlightAll = function (event) {
+    var strokeScale = this.getStrokeScale() || 1;
+    var strokeWidth = 1;
+
+    _self.annotations.forEach(function (annotation) {
+      strokeWidth = parseFloat(annotation._attrs["stroke-width"]) || 1;
+      strokeWidth = strokeWidth * strokeScale * 2 || 5;
+      annotation.highlight({
+        "stroke-width": strokeWidth === 0 ? 5 : strokeWidth,
+        // "stroke" : "yellow",
+      });
+    });
+  };
+
+  // Render a g container to contain annotation objects
+  this.render = function () {
+    var svg = d3.select(this.parent.svg).append("g").attr("id", this.id);
+
+    this.svg = svg;
+  };
+
+  // Remove an annotation by graphID
+  this.removeAnnotationByID = function (graphID) {
+    var index;
+    var annotation = this.annotations.find(function (graph, i) {
+      if (graph.id == graphID) {
+        index = i;
+        return true;
+      }
+    });
+
+    if (!annotation) {
+      return;
+    }
+
+    // remove annotation object from the collection
+    this.annotations.splice(index, 1);
+
+    // remove event handlers for the annotation
+    annotation.unbind();
+
+    // remove svg element
+    annotation.svg.remove();
+  };
+
+  // Remove all annotations
+  this.removeAllAnnotations = function () {
+    this.annotations.forEach(function (annotation) {
+      // remove event handlers for the annotation
+      annotation.unbind();
+
+      // remove svg element
+      annotation.svg.remove();
+    });
+
+    // remove from the collection
+    this.annotations = [];
+  };
+
+  this.setAttributesByJSON = function (attrs) {
+    var attr, value;
+
+    for (attr in attrs) {
+      value = attrs[attr];
+      switch (attr) {
+        case "description":
+        case "anatomy":
+          this[attr] = value;
+          break;
+      }
+    }
+  };
+
+  this.setDisplay = function (isDisplay) {
+    var displayStyle = isDisplay ? "block" : "none";
+    this.isDisplay = isDisplay;
+    this.svg.attr("display", displayStyle);
+  };
+
+  this.updateDiagonalPoints = function () {
+    // Set the annotation group boundaries based on the annotation
+    for (var i = 0; i < this.annotations.length; i++) {
+      var annotation = this.annotations[i];
+      var bbox = annotation.svg.node().getBBox();
+      this.x1 = this.x1 == null || bbox.x < this.x1 ? bbox.x : this.x1;
+      this.y1 = this.y1 == null || bbox.y < this.y1 ? bbox.y : this.y1;
+      this.x2 = bbox.x + bbox.width > this.x2 ? bbox.x + bbox.width : this.x2;
+      this.y2 = bbox.y + bbox.height > this.y2 ? bbox.y + bbox.height : this.y2;
+    }
+  };
+
+  this.updateStrokeWidth = function () {
+    _self.annotations.forEach(function (annotation) {
+      annotation.renderSVG();
+    });
+  };
+
+  /**
+   * Given an annotation, will update the this.stroke Array
+   * @param {Base} annot
+   */
+  this.setGroupStrokeByAnnotation = function (annot) {
+    var stroke = _self.parent.parent._utils.standardizeColor(
+      annot._attrs.stroke
+    );
+
+    if (_self.stroke.indexOf(stroke) === -1) {
+      _self.stroke.push(stroke);
+    }
+  };
+
+  /**
+   * This function changes the color(stroke) of the each annotation to the new value passed as param
+   * @param {string} stroke the RGB value of the new color
+   */
+  this.updateStroke = function (stroke) {
+    var stroke = _self.parent.parent._utils.standardizeColor(stroke);
+
+    _self.stroke = [stroke];
+    _self.annotations.forEach(function (annotation) {
+      annotation._attrs.stroke = stroke;
+      // render the SVG after changing the color so that the new color is reflected in the viewer
+      annotation.renderSVG();
+    });
+  };
+
+  this.updateInfo = function (data) {
+    this.id = data.id;
+    this.anatomy = data.anatomy;
+    this.svg.attr("id", this.id);
+  };
+
+  this.unHighlightAll = function () {
+    _self.annotations.forEach(function (annotation) {
+      annotation.unHighlight();
+    });
+  };
 }

--- a/js/viewer/annotation/annotation-svg.js
+++ b/js/viewer/annotation/annotation-svg.js
@@ -1,603 +1,686 @@
-function AnnotationSVG(parent, id, imgWidth, imgHeight, scale, ignoreReferencePoint, ignoreDimension){
-    this.id = id;
-    this.svg = null;
-    this.parent = parent;
-    this.scale = scale;
-    this.imgScaleX = 1;
-    this.imgScaleY = 1;
-    this.imgWidth = imgWidth;
-    this.imgHeight = imgHeight;
-    // reference point to the actual images
-    this.ignoreReferencePoint = ignoreReferencePoint;
-    this.ignoreDimension = ignoreDimension;
-    this.upperLeftPoint = null;
-    this.bottomRightPoint = null;
-    this.groups = {};
-    this.isSelected = false;
-    this.currentGroupID = "";
+function AnnotationSVG(
+  parent,
+  id,
+  imgWidth,
+  imgHeight,
+  scale,
+  ignoreReferencePoint,
+  ignoreDimension
+) {
+  this.id = id;
+  this.svg = null;
+  this.parent = parent;
+  this.scale = scale;
+  this.imgScaleX = 1;
+  this.imgScaleY = 1;
+  this.imgWidth = imgWidth;
+  this.imgHeight = imgHeight;
+  // reference point to the actual images
+  this.ignoreReferencePoint = ignoreReferencePoint;
+  this.ignoreDimension = ignoreDimension;
+  this.upperLeftPoint = null;
+  this.bottomRightPoint = null;
+  this.groups = {};
+  this.isSelected = false;
+  this.currentGroupID = "";
 
-    this.annotationUtils = new AnnotationUtils();
+  this.annotationUtils = new AnnotationUtils();
 
-    // Create drawing area for grouping annotations with same id
-    this.createAnnotationGroup = function (id, anatomy, description) {
-        // Check if the area has created
-        id = id ? id : Date.parse(new Date());
-        var isGroupEmpty = this.groups.hasOwnProperty(id) ? false : true;
-        var group = null;
+  // Add the marker definition to the SVG for arrow line annotation
+  this.addMarkerDef = function (attrs, markerId) {
+    // Check if the definition is already added
+    if (this.svg.querySelector("#" + markerId)) {
+      return;
+    }
+    var defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
+    var marker = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "marker"
+    );
+    marker.setAttributeNS(null, "id", markerId);
+    marker.setAttributeNS(null, "refX", 9.3);
+    marker.setAttributeNS(null, "refY", 5);
+    marker.setAttributeNS(null, "markerUnits", "strokeWidth");
+    marker.setAttributeNS(null, "markerWidth", 10);
+    marker.setAttributeNS(null, "markerHeight", 10);
+    marker.setAttributeNS(null, "orient", "auto");
+    var path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttributeNS(null, "fill", attrs.stroke);
+    path.setAttributeNS(null, "d", "M 0 0 L 10 5 L 0 10 z");
+    marker.appendChild(path);
+    defs.appendChild(marker);
+    this.svg.appendChild(defs);
+  };
 
-        // Check if annotation id has already existed and create one if not
-        if (isGroupEmpty) {
-            group = new AnnotationGroup(id, anatomy, description, this);
-            group.render();
-            this.groups[id] = group;
-            return group;
-        }
+  // Create drawing area for grouping annotations with same id
+  this.createAnnotationGroup = function (id, anatomy, description) {
+    // Check if the area has created
+    id = id ? id : Date.parse(new Date());
+    var isGroupEmpty = this.groups.hasOwnProperty(id) ? false : true;
+    var group = null;
+
+    // Check if annotation id has already existed and create one if not
+    if (isGroupEmpty) {
+      group = new AnnotationGroup(id, anatomy, description, this);
+      group.render();
+      this.groups[id] = group;
+      return group;
+    }
+  };
+
+  // Create a new path/rect/circle object for users to draw
+  this.createAnnotationObject = function (groupID, type, attrs) {
+    var group, annotation;
+
+    if (this.groups.hasOwnProperty(groupID)) {
+      // Add the marker definition to the SVG for arrowhead if the annotation type is arrow line
+      if (type == "ARROWLINE") {
+        this.addMarkerDef(attrs, "arrow");
+      }
+      // Find corresponding group
+      group = this.groups[groupID];
+
+      // Start to draw annotation
+      annotation = group.addAnnotation(type);
+      annotation.renderSVG(group);
+      annotation.setupDrawingAttrs(attrs);
+
+      this.dispatchEvent("onDrawingBegin", {
+        svgID: this.id,
+        groupID: groupID,
+        graphID: annotation.id,
+        viewBox: this.getViewBox(),
+        imgScaleX: this.imgScaleX,
+        imgScaleY: this.imgScaleY,
+        annotation: annotation,
+        type: type,
+        attrs: attrs,
+      });
+    }
+  };
+
+  /**
+   * This function changes the color of the annotation that is worked on, to the new color passes in the data
+   * @param {object} data Contain information about the object that is being drawn/editted
+   */
+  this.changeDrawingStroke = function (data) {
+    // Change the fill color of the path in marker definition to change the colour of the arrow head on stroke colour change
+    var markerPath = this.svg
+      .querySelector("#arrow")
+      .getElementsByTagName("path");
+    markerPath[0].setAttribute("fill", data.attrs.stroke);
+
+    for (var groupID in this.groups) {
+      // change the color for only the group that is being worked on
+      if (groupID == data.groupID) {
+        this.groups[groupID].updateStroke(data.attrs.stroke);
+      }
+    }
+  };
+
+  // Change the group visibility
+  this.changeVisibility = function (data) {
+    if (this.groups.hasOwnProperty(data.groupID)) {
+      this.hideGroupBorder();
+      var group = this.groups[data.groupID];
+      group.setDisplay(data.isDisplay);
+    }
+  };
+
+  // Change all groups visibility
+  this.changeAllVisibility = function (isDisplay) {
+    var groupID;
+    for (groupID in this.groups) {
+      group = this.groups[groupID];
+      group.setDisplay(isDisplay);
     }
 
-    // Create a new path/rect/circle object for users to draw
-    this.createAnnotationObject = function(groupID, type, attrs){
+    if (!isDisplay) {
+      this.hideGroupBorder();
+    }
+  };
 
-        var group,
-            annotation;
+  // Change SVG ID
+  this.changeSVGId = function (data) {
+    if (this.id === data.svgID) {
+      this.id = data.newSvgID;
+      this.dispatchEvent("updateSVGId", data);
+    }
+  };
 
-        if(this.groups.hasOwnProperty(groupID)){
-            // Find corresponding group
-            group = this.groups[groupID];
+  this.changeGroupInfo = function (data) {
+    if (this.groups.hasOwnProperty(data.groupID)) {
+      var prevGroup = this.groups[data.groupID];
+      prevGroup.updateInfo({
+        id: data.newGroupID,
+        anatomy: data.newAnatomy,
+      });
 
-            // Start to draw annotation
-            annotation = group.addAnnotation(type);
-            annotation.renderSVG(group);
-            annotation.setupDrawingAttrs(attrs);
+      this.groups[data.newGroupID] = prevGroup;
 
-            this.dispatchEvent("onDrawingBegin", {
-                svgID : this.id,
-                groupID : groupID,
-                graphID : annotation.id,
-                viewBox : this.getViewBox(),
-                imgScaleX : this.imgScaleX,
-                imgScaleY : this.imgScaleY,
-                annotation : annotation,
-                type : type,
-                attrs : attrs
-            })
+      if (this.currentGroupID === data.groupID) {
+        this.currentGroupID = data.newGroupID;
+      }
+
+      delete this.groups[data.groupID];
+
+      this.dispatchEvent("updateGroupInfo", data);
+    }
+  };
+
+  this.changeSelectedGroup = function (data) {
+    if (this.currentGroupID == data.groupID) {
+      if (this.groups.hasOwnProperty(this.currentGroupID)) {
+        var group = this.groups[this.currentGroupID];
+        group.isSelected = false;
+        group.unHighlightAll();
+        this.hideGroupBorder();
+      }
+      this.currentGroupID = "";
+    } else {
+      if (this.groups.hasOwnProperty(this.currentGroupID)) {
+        var group = this.groups[this.currentGroupID];
+        group.isSelected = false;
+        group.unHighlightAll();
+        this.hideGroupBorder();
+      }
+
+      if (
+        this.groups.hasOwnProperty(data.groupID) &&
+        data.groupID != this.currentGroupID
+      ) {
+        var group = this.groups[data.groupID];
+        group.highlightAll();
+        group.isSelected = true;
+        this.currentGroupID = data.groupID;
+
+        // Bring up the element to the front
+        this.svg.append(group.svg.node());
+
+        // data["x1"] = this.upperLeftPoint.x + group["x1"] * this.xUnit;
+        // data["x2"] = this.upperLeftPoint.x + group["x2"] * this.xUnit;
+        // data["y1"] = this.upperLeftPoint.y + group["y1"] * this.yUnit;
+        // data["y2"] = this.upperLeftPoint.y + group["y2"] * this.yUnit;
+
+        // Show border if the group's visibility set to true
+        if (group.isDisplay) {
+          this.showGroupBorder({
+            x1: group["x1"],
+            y1: group["y1"],
+            x2: group["x2"],
+            y2: group["y2"],
+          });
         }
+      }
     }
 
-    /**
-    * This function changes the color of the annotation that is worked on, to the new color passes in the data
-    * @param {object} data Contain information about the object that is being drawn/editted
-    */
-    this.changeDrawingStroke = function (data) {
-        for (var groupID in this.groups) {
-            // change the color for only the group that is being worked on
-            if (groupID == data.groupID) {
-                this.groups[groupID].updateStroke(data.attrs.stroke);
-            }
+    data["svgID"] = this.id;
+    // data["groupID"] = this.currentGroupID;
+  };
+
+  this.changeStrokeScale = function (data) {
+    for (var groupID in this.groups) {
+      this.groups[groupID].updateStrokeWidth();
+
+      if (this.currentGroupID == groupID) {
+        this.groups[groupID].highlightAll();
+      }
+    }
+  };
+
+  this.dispatchEvent = function (type, data) {
+    switch (type) {
+      // Change the selecting annotation
+      case "onClickChangeSelectingAnnotation":
+        data.svgID = this.id;
+        this.parent.dispatchEvent(type, data);
+        break;
+      case "onMouseoverShowTooltip":
+        this.unHighlightCurrentGroup(data.groupID);
+        this.showGroupBorder(data);
+        this.parent.dispatchEvent(type, data);
+        break;
+      case "onMouseoutHideTooltip":
+        this.highlightCurrentGroup();
+        this.hideGroupBorder();
+        this.parent.dispatchEvent(type, data);
+        break;
+      default:
+        this.parent.dispatchEvent(type, data);
+        break;
+    }
+  };
+
+  /**
+   * export a list of svg files
+   * each svg file only contains one anatomy ID
+   * @param groupID : the group id
+   * @return Array of objects that contains svg content of each group
+   */
+  this.exportToSVG = function (groupID) {
+    var rst = [];
+    var svg = "";
+    var imgScaleX = this.imgScaleX ? this.imgScaleX : 1;
+    var imgScaleY = this.imgScaleY ? this.imgScaleY : 1;
+
+    // return matched group SVG content only if groupID provided
+    if (groupID) {
+      if (this.groups.hasOwnProperty(groupID)) {
+        var innerSVG = this.groups[groupID].exportToSVG();
+        if (innerSVG != "") {
+          // if there is some content present in the innerSVG, only then add to rst, else return empty array.
+          svg +=
+            "<svg viewBox='" +
+            this.getViewBox().join(" ") +
+            "' xmlns='http://www.w3.org/2000/svg'  xmlns:xlink='http://www.w3.org/1999/xlink'>";
+          svg += "<scale x='" + imgScaleX + "' y='" + imgScaleY + "'/>";
+          svg += innerSVG;
+          svg += "</svg>";
+
+          rst.push({
+            svgID: this.id,
+            groupID: groupID,
+            numOfAnnotations: this.groups[groupID].getNumOfAnnotations(),
+            svg: svg,
+            stroke: this.groups[groupID].stroke,
+          });
         }
+      }
     }
 
-    // Change the group visibility
-    this.changeVisibility = function(data){
+    return rst;
+  };
 
-        if(this.groups.hasOwnProperty(data.groupID)){
-            this.hideGroupBorder();
-            var group = this.groups[data.groupID];
-            group.setDisplay(data.isDisplay);
-        }
+  this.getStrokeScale = function () {
+    return this.parent.getStrokeScale();
+  };
+
+  // get viewbox of the svg
+  this.getViewBox = function () {
+    return this.viewBox ? this.viewBox : [0, 0, this.imgWidth, this.imgHeight];
+  };
+
+  // highlight current group when user leave the hovering group
+  this.highlightCurrentGroup = function () {
+    if (this.currentGroupID != "") {
+      var group = this.groups[this.currentGroupID];
+      group.highlightAll();
+    }
+  };
+
+  // Hide border of annotation group
+  this.hideGroupBorder = function () {
+    d3.select(this.svg).selectAll("rect.groupBorder").remove();
+  };
+
+  this.parseSVGFile = function (svgFile) {
+    var self = this;
+
+    if (!svgFile) {
+      return;
     }
 
-    // Change all groups visibility
-    this.changeAllVisibility = function(isDisplay){
-        var groupID;
-        for (groupID in this.groups) {
-            group = this.groups[groupID];
-            group.setDisplay(isDisplay);
-        }
-
-        if(!isDisplay){
-            this.hideGroupBorder();
-        }
-    }
-
-    // Change SVG ID
-    this.changeSVGId = function(data){
-
-        if(this.id === data.svgID){
-            this.id = data.newSvgID;
-            this.dispatchEvent("updateSVGId", data);
-        }
-    }
-
-    this.changeGroupInfo = function(data){
-
-        if(this.groups.hasOwnProperty(data.groupID)){
-            var prevGroup = this.groups[data.groupID];
-            prevGroup.updateInfo({
-                id : data.newGroupID,
-                anatomy : data.newAnatomy
-            })
-
-            this.groups[data.newGroupID] = prevGroup;
-
-            if(this.currentGroupID === data.groupID){
-                this.currentGroupID = data.newGroupID;
-            };
-
-            delete this.groups[data.groupID];
-
-            this.dispatchEvent("updateGroupInfo", data);
-        }
-    }
-
-    this.changeSelectedGroup = function(data){
-
-        if(this.currentGroupID == data.groupID){
-            if(this.groups.hasOwnProperty(this.currentGroupID)){
-                var group = this.groups[this.currentGroupID];
-                group.isSelected = false;
-                group.unHighlightAll();
-                this.hideGroupBorder();
-            }
-            this.currentGroupID = "";
-        }
-        else{
-            if(this.groups.hasOwnProperty(this.currentGroupID)){
-                var group = this.groups[this.currentGroupID];
-                group.isSelected = false;
-                group.unHighlightAll();
-                this.hideGroupBorder();
-            }
-
-            if(this.groups.hasOwnProperty(data.groupID) && data.groupID != this.currentGroupID){
-                var group = this.groups[data.groupID];
-                group.highlightAll();
-                group.isSelected = true;
-                this.currentGroupID = data.groupID;
-
-                // Bring up the element to the front
-                this.svg.append(group.svg.node());
-
-                // data["x1"] = this.upperLeftPoint.x + group["x1"] * this.xUnit;
-                // data["x2"] = this.upperLeftPoint.x + group["x2"] * this.xUnit;
-                // data["y1"] = this.upperLeftPoint.y + group["y1"] * this.yUnit;
-                // data["y2"] = this.upperLeftPoint.y + group["y2"] * this.yUnit;
-
-                    // Show border if the group's visibility set to true
-                if(group.isDisplay){
-                    this.showGroupBorder({
-                        x1 : group["x1"],
-                        y1 : group["y1"],
-                        x2 : group["x2"],
-                        y2 : group["y2"]
-                    });
-                }
-
-            }
-        }
-
-
-        data["svgID"] = this.id;
-        // data["groupID"] = this.currentGroupID;
-
-    }
-
-    this.changeStrokeScale = function(data){
-
-        for(var groupID in this.groups){
-            this.groups[groupID].updateStrokeWidth();
-
-            if(this.currentGroupID == groupID){
-                this.groups[groupID].highlightAll();
-            }
-        }
-    }
-
-    this.dispatchEvent = function(type, data){
-        switch(type){
-            // Change the selecting annotation
-            case "onClickChangeSelectingAnnotation":
-                data.svgID = this.id;
-                this.parent.dispatchEvent(type, data);
-                break;
-            case "onMouseoverShowTooltip":
-                this.unHighlightCurrentGroup(data.groupID);
-                this.showGroupBorder(data);
-                this.parent.dispatchEvent(type, data);
-                break;
-            case "onMouseoutHideTooltip":
-                this.highlightCurrentGroup();
-                this.hideGroupBorder();
-                this.parent.dispatchEvent(type, data);
-                break;
-            default:
-                this.parent.dispatchEvent(type, data);
-                break;
-        }
-
-    }
-
-    /**
-     * export a list of svg files
-     * each svg file only contains one anatomy ID
-     * @param groupID : the group id
-     * @return Array of objects that contains svg content of each group
-     */
-    this.exportToSVG = function(groupID){
-        var rst = [];
-        var svg = "";
-        var imgScaleX = (this.imgScaleX) ? this.imgScaleX : 1;
-        var imgScaleY = (this.imgScaleY) ? this.imgScaleY : 1;
-
-        // return matched group SVG content only if groupID provided
-        if(groupID){
-            if(this.groups.hasOwnProperty(groupID)){
-                var innerSVG = this.groups[groupID].exportToSVG();
-                if (innerSVG != "") {
-                    // if there is some content present in the innerSVG, only then add to rst, else return empty array.
-                    svg += "<svg viewBox='" + this.getViewBox().join(" ") + "' xmlns='http://www.w3.org/2000/svg'  xmlns:xlink='http://www.w3.org/1999/xlink'>";
-                    svg += "<scale x='" + imgScaleX + "' y='" + imgScaleY + "'/>";
-                    svg += innerSVG;
-                    svg += "</svg>";
-
-                    rst.push({
-                        svgID: this.id,
-                        groupID: groupID,
-                        numOfAnnotations: this.groups[groupID].getNumOfAnnotations(),
-                        svg: svg,
-                        stroke: this.groups[groupID].stroke
-                    });
-                }
-            }
-        }
-
-        return rst;
-    }
-
-    this.getStrokeScale = function(){
-        return this.parent.getStrokeScale();
-    }
-
-    // get viewbox of the svg
-    this.getViewBox = function(){
-        return (this.viewBox) ? this.viewBox : [0, 0, this.imgWidth, this.imgHeight];
-    }
-
-    // highlight current group when user leave the hovering group
-    this.highlightCurrentGroup = function(){
-        if(this.currentGroupID != ""){
-            var group = this.groups[this.currentGroupID];
-            group.highlightAll();
-        }
-    }
-
-    // Hide border of annotation group
-    this.hideGroupBorder = function () {
-        d3.select(this.svg)
-            .selectAll("rect.groupBorder")
-            .remove();
-    }
-
-    this.parseSVGFile = function(svgFile){
-        var self = this;
-
-        if(!svgFile){ return; }
-
-        // to set the viewBox attribute of the svg, first it is checked of the attributes exsists in the svg file itself or not. If it does exsist then that value is assigned, otherwise we look for the min-x, min-y, height and width attribute in the svg file and assign [min-x, min-y, height, width]. If none of these are present we display an error in the console.
-        if (svgFile.getAttribute("viewBox")) {
-            this.viewBox = svgFile.getAttribute("viewBox").split(" ").map(
-                function (num) {
-                    return +num;
-                }
-            );
-        } else if (svgFile.getAttribute("height") && svgFile.getAttribute("width")) {
-            var minX = parseInt(svgFile.getAttribute("min-x")) || 0;
-            var minY = parseInt(svgFile.getAttribute("min-y")) || 0;
-            this.viewBox = [minX, minY, parseInt(svgFile.getAttribute("width")), parseInt(svgFile.getAttribute("height"))];
-        }
-
-        if(!this.viewBox || this.viewBox.length != 4){
-            console.log("SVG file is missing the viewBox attribute");
-            return ;
-        }
-
-        this.render();
-
-
-        // Add SVG stylesheet to the document to get the css rules
-        var styleSheet = {}
-        if(svgFile.getElementsByTagName("style").length > 0){
-            document.getElementsByTagName("head")[0].append(svgFile.getElementsByTagName("style")[0])
-            // Get the SVG stylesheet rules and remove the style tag from document
-            var svgStyleSheet = document.styleSheets[document.styleSheets.length - 1].cssRules;
-            var styleTags = document.getElementsByTagName("style");
-            styleTags[styleTags.length - 1].remove();
-
-            // Parsing the css class rules
-            for (var j = 0; j < svgStyleSheet.length; j++) {
-                var className = svgStyleSheet[j].selectorText.replace(".", ""),
-                    index = 0,
-                    attr,
-                    value;
-
-                styleSheet[className] = {};
-                while (svgStyleSheet[j].style[index]) {
-                    attr = svgStyleSheet[j].style[index];
-                    value = svgStyleSheet[j].style[attr];
-                    styleSheet[className][attr] = value;
-                    index += 1;
-                }
-            }
-        }
-
-        // Parsing child nodes in SVG
-        var svgElems = svgFile.childNodes || [];
-
-        for (var i = 0; i < svgElems.length; i++) {
-
-            if (!svgElems[i].getAttribute) { continue; }
-            // if (svgElems[i].getAttribute("id") == null) { continue; }
-
-            var node = svgElems[i];
-            // var groupID = svgElems[i].getAttribute("id") || Date.parse(new Date()) + parseInt(Math.random() * 1000);
-            var className = node.getAttribute("class") || "";
-            var attrs = styleSheet[className] ? JSON.parse(JSON.stringify(styleSheet[className])) : {};
-            // var anatomy = node.getAttribute("id");
-            // var group = this.createAnnotationGroup(groupID, anatomy);
-
-            switch (node.nodeName) {
-                case "g":
-                    this.parseSVGNodes(node.childNodes, styleSheet, node);
-                    break;
-                case "path":
-                case "circle":
-                case "polyline":
-                case "polygon":
-                case "rect":
-                case "line":
-                    this.parseSVGNodes([node], styleSheet, node);
-                    // annotation = group.addAnnotation(node.nodeName);
-                    // annotation.setAttributesBySVG(node);
-                    // annotation.renderSVG(this);
-                    break;
-                case "scale":
-                    this.imgScaleX = +node.getAttribute("x") || this.imgScaleX;
-                    this.imgScaleY = +node.getAttribute("y") || this.imgScaleY;
-                    break;
-            }
-        }
-
-        // sort the groups based on their anatomy value
-        var annotList = Object.keys(this.groups).sort(function (keyA, keyB) {
-            var anatA = self.groups[keyA].anatomy,
-                anatB = self.groups[keyB].anatomy;
-            return (anatA > anatB) ? 1 : ((anatA < anatB) ? -1 : 0);
-        }).map(function (id) {
-            // create the list of annotations that UI has to display
-            var group = self.groups[id];
-            return {
-                svgID: self.id,
-                groupID: group.id,
-                anatomy : group.anatomy,
-                description : group.description,
-                stroke: group.stroke
-            }
+    // to set the viewBox attribute of the svg, first it is checked of the attributes exsists in the svg file itself or not. If it does exsist then that value is assigned, otherwise we look for the min-x, min-y, height and width attribute in the svg file and assign [min-x, min-y, height, width]. If none of these are present we display an error in the console.
+    if (svgFile.getAttribute("viewBox")) {
+      this.viewBox = svgFile
+        .getAttribute("viewBox")
+        .split(" ")
+        .map(function (num) {
+          return +num;
         });
-
-        // update the annotation list
-        // NOTE this has to be here, because the stroke value changes will
-        //      processing the annotation list. We cannot send this right away
-        this.dispatchEvent('updateAnnotationList', annotList);
+    } else if (
+      svgFile.getAttribute("height") &&
+      svgFile.getAttribute("width")
+    ) {
+      var minX = parseInt(svgFile.getAttribute("min-x")) || 0;
+      var minY = parseInt(svgFile.getAttribute("min-y")) || 0;
+      this.viewBox = [
+        minX,
+        minY,
+        parseInt(svgFile.getAttribute("width")),
+        parseInt(svgFile.getAttribute("height")),
+      ];
     }
 
-    /**
-     * Checks all the style attributes in the node and returns the in the form of a string
-     * @param {object} node
-     * @return {string} the returned value is a string that is similar to the 'style' attribute of a node i.e. style in a svg node.
-     */
-    this.getStyleAttributes = function (node) {
+    if (!this.viewBox || this.viewBox.length != 4) {
+      console.log("SVG file is missing the viewBox attribute");
+      return;
+    }
 
-        styleAttributeList = parent.config.constants.STYLE_ATTRIBUTE_LIST;
+    this.render();
 
-        styleAttributeString = '';
+    // Add SVG stylesheet to the document to get the css rules
+    var styleSheet = {};
+    if (svgFile.getElementsByTagName("style").length > 0) {
+      document
+        .getElementsByTagName("head")[0]
+        .append(svgFile.getElementsByTagName("style")[0]);
+      // Get the SVG stylesheet rules and remove the style tag from document
+      var svgStyleSheet =
+        document.styleSheets[document.styleSheets.length - 1].cssRules;
+      var styleTags = document.getElementsByTagName("style");
+      styleTags[styleTags.length - 1].remove();
 
-        for (let i = 0; i < styleAttributeList.length; i++) {
-            if (node.getAttribute(styleAttributeList[i])) {
-                value = node.getAttribute(styleAttributeList[i]);
-                styleAttributeString += styleAttributeList[i] + ':' + value + ';';
+      // Parsing the css class rules
+      for (var j = 0; j < svgStyleSheet.length; j++) {
+        var className = svgStyleSheet[j].selectorText.replace(".", ""),
+          index = 0,
+          attr,
+          value;
+
+        styleSheet[className] = {};
+        while (svgStyleSheet[j].style[index]) {
+          attr = svgStyleSheet[j].style[index];
+          value = svgStyleSheet[j].style[attr];
+          styleSheet[className][attr] = value;
+          index += 1;
+        }
+      }
+    }
+
+    // Parsing child nodes in SVG
+    var svgElems = svgFile.childNodes || [];
+
+    for (var i = 0; i < svgElems.length; i++) {
+      if (!svgElems[i].getAttribute) {
+        continue;
+      }
+      // if (svgElems[i].getAttribute("id") == null) { continue; }
+
+      var node = svgElems[i];
+      // var groupID = svgElems[i].getAttribute("id") || Date.parse(new Date()) + parseInt(Math.random() * 1000);
+      var className = node.getAttribute("class") || "";
+      var attrs = styleSheet[className]
+        ? JSON.parse(JSON.stringify(styleSheet[className]))
+        : {};
+      // var anatomy = node.getAttribute("id");
+      // var group = this.createAnnotationGroup(groupID, anatomy);
+
+      switch (node.nodeName) {
+        case "g":
+          this.parseSVGNodes(node.childNodes, styleSheet, node);
+          break;
+        case "path":
+        case "circle":
+        case "polyline":
+        case "polygon":
+        case "rect":
+        case "line":
+        case "arrowline":
+          this.parseSVGNodes([node], styleSheet, node);
+          // annotation = group.addAnnotation(node.nodeName);
+          // annotation.setAttributesBySVG(node);
+          // annotation.renderSVG(this);
+          break;
+        case "scale":
+          this.imgScaleX = +node.getAttribute("x") || this.imgScaleX;
+          this.imgScaleY = +node.getAttribute("y") || this.imgScaleY;
+          break;
+      }
+    }
+
+    // sort the groups based on their anatomy value
+    var annotList = Object.keys(this.groups)
+      .sort(function (keyA, keyB) {
+        var anatA = self.groups[keyA].anatomy,
+          anatB = self.groups[keyB].anatomy;
+        return anatA > anatB ? 1 : anatA < anatB ? -1 : 0;
+      })
+      .map(function (id) {
+        // create the list of annotations that UI has to display
+        var group = self.groups[id];
+        return {
+          svgID: self.id,
+          groupID: group.id,
+          anatomy: group.anatomy,
+          description: group.description,
+          stroke: group.stroke,
+        };
+      });
+
+    // update the annotation list
+    // NOTE this has to be here, because the stroke value changes will
+    //      processing the annotation list. We cannot send this right away
+    this.dispatchEvent("updateAnnotationList", annotList);
+  };
+
+  /**
+   * Checks all the style attributes in the node and returns the in the form of a string
+   * @param {object} node
+   * @return {string} the returned value is a string that is similar to the 'style' attribute of a node i.e. style in a svg node.
+   */
+  this.getStyleAttributes = function (node) {
+    styleAttributeList = parent.config.constants.STYLE_ATTRIBUTE_LIST;
+
+    styleAttributeString = "";
+
+    for (let i = 0; i < styleAttributeList.length; i++) {
+      if (node.getAttribute(styleAttributeList[i])) {
+        value = node.getAttribute(styleAttributeList[i]);
+        styleAttributeString += styleAttributeList[i] + ":" + value + ";";
+      }
+    }
+    return styleAttributeString;
+  };
+
+  /**
+   * Take the properties from the parent style and appends them to the child node if they are missing from the child.
+   * @param {string} parentStyle
+   * @param {string} selfStyle
+   * @return {string}
+   */
+  this.mergeWithParentStyle = function (parentStyle, selfStyle) {
+    if (parentStyle != "") {
+      parentStyle = this.annotationUtils.styleStringToObject(parentStyle);
+      selfStyle = this.annotationUtils.styleStringToObject(selfStyle);
+
+      for (let key in parentStyle) {
+        if (!selfStyle[key]) {
+          selfStyle[key] = parentStyle[key];
+        }
+      }
+
+      return this.annotationUtils.styleObjectToString(selfStyle);
+    }
+
+    return selfStyle;
+  };
+
+  /**
+   * Returns the node ID, which can is defined by the following logic: if the node has an ID return that else check for the name attribute in the node. If name is not present then check if the parent of that node has an ID, if yes then return that. In case non of these are present, then return a constant.
+   * @param {object} node
+   * @param {object} parentNode
+   * @return {string}
+   */
+  this.getNodeID = function (node, parentNode) {
+    return (
+      node.getAttribute("id") ||
+      node.getAttribute("name") ||
+      parentNode.getAttribute("id") ||
+      parent.config.constants.UNKNOWN_ANNNOTATION
+    );
+  };
+
+  /**
+   * This function return the set of attributes in the form of an object {attr: value}, from the input object which has otehr properties as well.
+   * @param {object} node
+   * @return {object}
+   */
+  this.getNodeAttributes = function (node) {
+    attributes = node.attributes || {};
+    var obj = {};
+    for (i = 0; i < attributes.length; i++) {
+      obj[attributes[i]["name"]] = attributes[i]["nodeValue"];
+    }
+    return obj;
+  };
+
+  this.parseSVGNodes = function (nodes, styleSheet, parentNode) {
+    // if (group == null) { return }
+
+    var parentStyle = "";
+    if (parentNode) {
+      parentStyle = parentNode.getAttribute("style") || "";
+    } else {
+      parentNode = {};
+    }
+
+    for (var i = 0; i < nodes.length; i++) {
+      if (!nodes[i].getAttribute) {
+        continue;
+      }
+
+      var node = nodes[i];
+      var id = this.getNodeID(node, parentNode);
+      node.setAttribute("id", id);
+      var anatomy =
+        id.split(",").length > 1
+          ? id.split(",")[1] + " (" + id.split(",")[0] + ")"
+          : id;
+      var className = node.getAttribute("class") || "";
+      var group = null;
+
+      var selfStyle = node.getAttribute("style") || "";
+      if (parentStyle != "") {
+        selfStyle = this.mergeWithParentStyle(parentStyle, selfStyle);
+        node.setAttribute("style", selfStyle);
+      }
+
+      var attrs = this.annotationUtils.styleStringToObject(
+        node.getAttribute("style")
+      );
+      for (attr in attrs) {
+        node.setAttribute(attr, attrs[attr]);
+      }
+      // var attrs = styleSheet[className] ? JSON.parse(JSON.stringify(styleSheet[className])) : {};
+
+      switch (node.nodeName) {
+        case "g":
+          this.parseSVGNodes(node.childNodes, styleSheet, node);
+          break;
+        case "path":
+        case "circle":
+        case "polyline":
+        case "polygon":
+        case "rect":
+          if (id !== "undefined") {
+            group = this.groups.hasOwnProperty(id)
+              ? this.groups[id]
+              : this.createAnnotationGroup(id, anatomy);
+            annotation = group.addAnnotation(node.nodeName);
+            annotation.setAttributesByJSON(this.getNodeAttributes(node));
+            annotation.renderSVG(this);
+          }
+          break;
+        // Separate case for line type as we need to check if the annotation is line or arrow line
+        case "line":
+          if (id !== "undefined") {
+            group = this.groups.hasOwnProperty(id)
+              ? this.groups[id]
+              : this.createAnnotationGroup(id, anatomy);
+            annotation = group.addAnnotation(node.nodeName);
+            annotation.setAttributesByJSON(this.getNodeAttributes(node));
+
+            // Check if the line contains marker-end attribute, which makes it an arrow line
+            if (annotation._attrs["marker-end"] === "url(#arrow)") {
+              // Create a different marker-id for each SVG with arrow line as the stroke colour would be different
+              var markerDefId = "arrow-" + annotation._attrs.stroke.slice(1);
+              this.addMarkerDef(annotation._attrs, markerDefId);
+
+              // Update the marker-end url to reflect the new marker-head with the corresponding stroke color
+              annotation._attrs["marker-end"] = "url(#" + markerDefId + ")";
+              annotation.renderSVG("arrowline");
+            } else {
+              annotation.renderSVG(this);
             }
-        }
-        return styleAttributeString;
+          }
+          break;
+        case "scale":
+          this.imgScaleX = +node.getAttribute("x") || this.imgScaleX;
+          this.imgScaleY = +node.getAttribute("y") || this.imgScaleY;
+          break;
+      }
+    }
+  };
+
+  this.render = function () {
+    if (this.svg != null) {
+      return;
     }
 
-    /**
-     * Take the properties from the parent style and appends them to the child node if they are missing from the child.
-     * @param {string} parentStyle
-     * @param {string} selfStyle
-     * @return {string}
-     */
-    this.mergeWithParentStyle = function (parentStyle, selfStyle) {
+    var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
 
+    svg.setAttribute("class", "annotationSVG");
+    svg.setAttribute("viewBox", this.getViewBox().join(" "));
+    svg.setAttribute("scale", this.scale);
+    svg.setAttribute("ignoreReferencePoint", this.ignoreReferencePoint);
+    svg.setAttribute("ignoreDimension", this.ignoreDimension);
 
-        if (parentStyle != '') {
-            parentStyle = this.annotationUtils.styleStringToObject(parentStyle);
-            selfStyle = this.annotationUtils.styleStringToObject(selfStyle);
-
-            for (let key in parentStyle) {
-                if (!selfStyle[key]) {
-                    selfStyle[key] = parentStyle[key];
-                }
-            }
-
-            return this.annotationUtils.styleObjectToString(selfStyle);
-        }
-
-        return selfStyle;
+    if (this.parent.svg) {
+      this.parent.svg.append(svg);
     }
 
-    /**
-     * Returns the node ID, which can is defined by the following logic: if the node has an ID return that else check for the name attribute in the node. If name is not present then check if the parent of that node has an ID, if yes then return that. In case non of these are present, then return a constant.
-     * @param {object} node
-     * @param {object} parentNode
-     * @return {string}
-     */
-    this.getNodeID = function(node, parentNode) {
-        return node.getAttribute("id") || node.getAttribute("name") || parentNode.getAttribute("id") || parent.config.constants.UNKNOWN_ANNNOTATION;
+    this.svg = svg;
+  };
+
+  // Remove all the annotations
+  this.removeAllGroups = function () {
+    var groupID;
+    var group;
+
+    for (groupID in this.groups) {
+      group = this.groups[groupID];
+
+      group.removeAllAnnotations();
+
+      // remove svg element
+      group.svg.remove();
+
+      delete this.groups[groupID];
     }
+  };
 
-    /**
-     * This function return the set of attributes in the form of an object {attr: value}, from the input object which has otehr properties as well.
-     * @param {object} node
-     * @return {object}
-     */
-    this.getNodeAttributes = function(node) {
-        attributes = node.attributes || {};
-        var obj = {}
-        for (i = 0; i < attributes.length; i++) {
-            obj[attributes[i]['name']] = attributes[i]['nodeValue'];
-        }
-        return obj;
+  // Remove annotation from a group
+  this.removeAnnotationByGraphID = function (groupID, graphID) {
+    if (this.groups.hasOwnProperty(groupID)) {
+      var group = this.groups[groupID];
+
+      group.removeAnnotationByID(graphID);
     }
+  };
 
+  this.showGroupBorder = function (data) {
+    var w = data.x2 - data.x1 > this.width ? this.width : data.x2 - data.x1;
+    var h = data.y2 - data.y1 > this.height ? this.height : data.y2 - data.y1;
+    var x1 = data.x1 < 0 ? 0 : data.x1;
+    var y1 = data.y1 < 0 ? 0 : data.y1;
 
-    this.parseSVGNodes = function (nodes, styleSheet, parentNode){
-        // if (group == null) { return }
+    d3.select(this.svg)
+      .append("rect")
+      .attr("class", "groupBorder")
+      .attr("x", x1)
+      .attr("y", y1)
+      .attr("width", w)
+      .attr("height", h)
+      .attr("fill", "none")
+      .attr("stroke-width", "2px")
+      .attr("stroke", "yellow");
+  };
 
-        var parentStyle = '';
-        if (parentNode) {
-            parentStyle = parentNode.getAttribute("style") || '';
-        } else {
-            parentNode = {};
-        }
-
-
-        for (var i = 0; i < nodes.length; i++) {
-
-            if (!nodes[i].getAttribute) { continue; }
-
-            var node = nodes[i];
-            var id = this.getNodeID(node, parentNode);
-            node.setAttribute("id", id);
-            var anatomy = id.split(",").length > 1 ? id.split(",")[1] + " ("+id.split(",")[0]+")" : id;
-            var className = node.getAttribute("class") || "";
-            var group = null;
-
-            var selfStyle = node.getAttribute("style") || "";
-            if (parentStyle != '') {
-                selfStyle = this.mergeWithParentStyle(parentStyle, selfStyle);
-                node.setAttribute("style", selfStyle);
-            }
-
-            var attrs = this.annotationUtils.styleStringToObject(node.getAttribute("style"));
-            for (attr in attrs) {
-                node.setAttribute(attr, attrs[attr]);
-            }
-            // var attrs = styleSheet[className] ? JSON.parse(JSON.stringify(styleSheet[className])) : {};
-
-            switch (node.nodeName) {
-                case "g":
-                    this.parseSVGNodes(node.childNodes, styleSheet, node);
-                    break;
-                case "path":
-                case "circle":
-                case "polyline":
-                case "polygon":
-                case "rect":
-                case "line":
-                    if(id !== "undefined"){
-                        group = this.groups.hasOwnProperty(id) ? this.groups[id] : this.createAnnotationGroup(id, anatomy);
-                        annotation = group.addAnnotation(node.nodeName);
-                        annotation.setAttributesByJSON(this.getNodeAttributes(node));
-                        annotation.renderSVG(this);
-                    }
-                    break;
-                case "scale":
-                    this.imgScaleX = +node.getAttribute("x") || this.imgScaleX;
-                    this.imgScaleY = +node.getAttribute("y") || this.imgScaleY;
-                    break;
-            }
-        }
+  this.setGroupAttributes = function (data) {
+    if (this.groups.hasOwnProperty(data.groupID)) {
+      var group = this.groups[data.groupID];
+      group.setAttributesByJSON(data);
     }
+  };
 
-    this.render = function(){
-        if(this.svg != null) {
-            return;
-        }
-
-        var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-
-        svg.setAttribute("class", "annotationSVG");
-        svg.setAttribute("viewBox", this.getViewBox().join(" "));
-        svg.setAttribute("scale", this.scale);
-        svg.setAttribute("ignoreReferencePoint", this.ignoreReferencePoint);
-        svg.setAttribute("ignoreDimension", this.ignoreDimension);
-
-        if(this.parent.svg){
-            this.parent.svg.append(svg);
-        }
-
-        this.svg = svg;
+  // Unhighlight current group when user hover on other group
+  this.unHighlightCurrentGroup = function (hoverGroupID) {
+    if (this.currentGroupID != "" && this.currentGroupID != hoverGroupID) {
+      if (this.groups.hasOwnProperty(this.currentGroupID)) {
+        var group = this.groups[this.currentGroupID];
+        group.unHighlightAll();
+      }
     }
-
-    // Remove all the annotations
-    this.removeAllGroups = function(){
-        var groupID;
-        var group;
-
-        for(groupID in this.groups){
-            group = this.groups[groupID]
-
-            group.removeAllAnnotations();
-
-            // remove svg element
-            group.svg.remove();
-
-            delete this.groups[groupID];
-        }
-    }
-
-    // Remove annotation from a group
-    this.removeAnnotationByGraphID = function(groupID, graphID){
-        if(this.groups.hasOwnProperty(groupID)){
-            var group = this.groups[groupID];
-
-            group.removeAnnotationByID(graphID);
-        }
-    }
-
-    this.showGroupBorder = function(data){
-        var w = data.x2 - data.x1 > this.width ? this.width : data.x2 - data.x1;
-        var h = data.y2 - data.y1 > this.height ? this.height : data.y2 - data.y1;
-        var x1 = (data.x1 < 0) ? 0 : data.x1;
-        var y1 = (data.y1 < 0) ? 0 : data.y1;
-
-        d3.select(this.svg)
-            .append("rect")
-            .attr("class", "groupBorder")
-            .attr("x", x1)
-            .attr("y", y1)
-            .attr("width", w)
-            .attr("height", h)
-            .attr("fill", "none")
-            .attr("stroke-width", "2px")
-            .attr("stroke", "yellow")
-    }
-
-    this.setGroupAttributes = function(data){
-
-        if(this.groups.hasOwnProperty(data.groupID)){
-            var group = this.groups[data.groupID];
-            group.setAttributesByJSON(data);
-        }
-    }
-
-    // Unhighlight current group when user hover on other group
-    this.unHighlightCurrentGroup = function(hoverGroupID){
-        if(this.currentGroupID != "" && this.currentGroupID != hoverGroupID){
-            if(this.groups.hasOwnProperty(this.currentGroupID)){
-                var group = this.groups[this.currentGroupID];
-                group.unHighlightAll();
-            }
-        }
-    }
-
+  };
 }

--- a/js/viewer/annotation/arrowline.js
+++ b/js/viewer/annotation/arrowline.js
@@ -1,0 +1,39 @@
+function ArrowLine(attrs) {
+  attrs = attrs ? attrs : {};
+  Base.call(this, attrs);
+
+  // This tag needs to be line as the HTML tag used for arrow line is line itself
+  this._tag = "line";
+  this._attrs["x1"] = attrs["x1"] || null;
+  this._attrs["y1"] = attrs["y1"] || null;
+  this._attrs["x2"] = attrs["x2"] || null;
+  this._attrs["y2"] = attrs["y2"] || null;
+  this.svg = null;
+}
+
+ArrowLine.prototype = Object.create(Base.prototype);
+ArrowLine.prototype.constructor = ArrowLine;
+
+ArrowLine.prototype.insertPoint = function (point) {
+  var _self = this;
+  var updateAttrs = {};
+
+  if (_self._attrs.x1 == null || _self._attrs.y1 == null) {
+    // when the line is first added both the start and end point are assigned the same.
+    updateAttrs = {
+      x1: point.x,
+      y1: point.y,
+      x2: point.x,
+      y2: point.y,
+    };
+  } else {
+    updateAttrs = {
+      x2: point.x,
+      y2: point.y,
+      // This marker-end line adds the arrow-head to the line
+      "marker-end": "url(#arrow)",
+    };
+  }
+  _self.setAttributesByJSON(updateAttrs);
+  _self.renderSVG("arrowline");
+};

--- a/js/viewer/annotation/base.js
+++ b/js/viewer/annotation/base.js
@@ -1,269 +1,277 @@
-function Base(attrs){
-    attrs = attrs ? attrs : {};
-    var _self = this;
-    this.parent = attrs.parent;
-    this.id = attrs["graph-id"] || -1;
-    this.isDrawing = false;
-    this.constants = attrs.parent.parent.parent.config.constants;
-    this.urlParams = attrs.parent.parent.parent.parameters;
+function Base(attrs) {
+  attrs = attrs ? attrs : {};
+  var _self = this;
+  this.parent = attrs.parent;
+  this.id = attrs["graph-id"] || -1;
+  this.isDrawing = false;
+  this.constants = attrs.parent.parent.parent.config.constants;
+  this.urlParams = attrs.parent.parent.parent.parameters;
 
-    // this is used to make sure that any property that is added to the SVG for display purpose, is not added while saving
-    this._addedAttributeNames = ["vector-effect"];
+  // this is used to make sure that any property that is added to the SVG for display purpose, is not added while saving
+  this._addedAttributeNames = ["vector-effect"];
 
-    // if this url parameter exists, we should honor the stroke width that are defined on SVG files
-    if (!this.urlParams.enableSVGStrokeWidth) {
-        this._addedAttributeNames.push("stroke-width");
+  // if this url parameter exists, we should honor the stroke width that are defined on SVG files
+  if (!this.urlParams.enableSVGStrokeWidth) {
+    this._addedAttributeNames.push("stroke-width");
+  }
+
+  // attributes that are used to display the SVG annotation in osd viewer
+  this._attrs = {
+    fill: "none", // TODO should this be part of added attributes as well?
+    stroke: this.constants.DEFAULT_SVG_STROKE,
+    "stroke-width": this.constants.DEFAULT_SVG_STROKE_WIDTH,
+    "vector-effect": this.constants.DEFAULT_SVG_VECTOR_EFFECT,
+    "marker-end": "url(#arrow)", //Added for the arrowline, this needs to be an attribute added to the HTML line tag
+  };
+
+  // the check that needs to be performed to prevent empty object
+  // can move this var to config and imported from there
+  this._attributeCheck = {
+    rect: ["height", "width"],
+    circle: ["cx", "cy", "r"],
+    path: ["d"],
+    line: ["x1", "x2", "y1", "y2"],
+    arrowline: ["x1", "x2", "y1", "y2"],
+    polygon: ["points"],
+  };
+
+  this._tag = "";
+
+  // it stores all the attributes that we are not handling right now, so that they can be added to the output SVG file
+  this._ignoredAttrs = {};
+
+  /**
+   * This functions checks to see if the svg component has valid attributes for it to be drawn. This function makes sure that no empty attribute is added.
+   * @param {object} attributes
+   * @return {boolean} Boolean values representing if the component has valid dimensions
+   */
+  this.hasDimensions = function (attributes, tag) {
+    // if the tag is not supported report the error
+    if (!this._attributeCheck[tag]) {
+      console.log(tag + " not supported currently");
+      return false;
     }
 
-    // attributes that are used to display the SVG annotation in osd viewer
-    this._attrs = {
-        "fill": "none", // TODO should this be part of added attributes as well?
-        "stroke": this.constants.DEFAULT_SVG_STROKE,
-        "stroke-width": this.constants.DEFAULT_SVG_STROKE_WIDTH,
-        "vector-effect": this.constants.DEFAULT_SVG_VECTOR_EFFECT
+    // check if all the required properties are present return false in case any of them is missing
+    for (i = 0; i < this._attributeCheck[tag].length; i++) {
+      if (!attributes[this._attributeCheck[tag][i]]) {
+        return false;
+      }
     }
 
-    // the check that needs to be performed to prevent empty object
-    // can move this var to config and imported from there
-    this._attributeCheck = {
-        "rect": ["height", "width"],
-        "circle": ["cx", "cy", "r"],
-        "path": ["d"],
-        "line": ["x1", "x2", "y1", "y2"],
-        "polygon": ["points"]
+    return true;
+  };
+
+  this.exportToSVG = function () {
+    // Check to see if there are necessary dimensions needed to construct the component. This makes sure that no empty components are added to the final SVG output file.
+    if (!this.hasDimensions(this._attrs, this._tag)) {
+      return "";
+    }
+    var tag = this._tag;
+    var rst = "<" + tag + " ";
+    var attr;
+    var attributeList = {};
+
+    for (attr in this._attrs) {
+      // only add non-empty attributes
+      if (!this._attrs[attr] || this._attrs[attr] === null) {
+        continue;
+      }
+
+      // don't add the attributes that are added by osd viewer
+      if (this._addedAttributeNames.indexOf(attr) !== -1) {
+        continue;
+      }
+
+      attributeList[attr] = this._attrs[attr];
     }
 
-    this._tag = "";
-
-    // it stores all the attributes that we are not handling right now, so that they can be added to the output SVG file
-    this._ignoredAttrs = {};
-
-    /**
-     * This functions checks to see if the svg component has valid attributes for it to be drawn. This function makes sure that no empty attribute is added.
-     * @param {object} attributes
-     * @return {boolean} Boolean values representing if the component has valid dimensions
-     */
-    this.hasDimensions = function(attributes, tag) {
-        // if the tag is not supported report the error
-        if (!this._attributeCheck[tag]) {
-            console.log(tag + " not supported currently");
-            return false;
-        }
-
-        // check if all the required properties are present return false in case any of them is missing
-        for (i = 0; i < this._attributeCheck[tag].length; i++) {
-            if (!attributes[this._attributeCheck[tag][i]]) {
-                return false;
-            }
-        }
-
-        return true;
+    // read the ignored attributes after this._attrs, to ensure that the values in the input and output match
+    for (attr in this._ignoredAttrs) {
+      attributeList[attr] = this._ignoredAttrs[attr];
     }
 
-    this.exportToSVG = function(){
+    // add the attributes in sorted order
+    Object.keys(attributeList)
+      .sort()
+      .forEach(function (key) {
+        rst += key + '="' + attributeList[key] + '" ';
+      });
 
-        // Check to see if there are necessary dimensions needed to construct the component. This makes sure that no empty components are added to the final SVG output file.
-        if (!this.hasDimensions(this._attrs, this._tag)) {
-            return "";
-        }
-        var tag = this._tag;
-        var rst = "<" + tag + " ";
-        var attr;
-        var attributeList = {}
+    rst += "></" + tag + ">";
+    return rst;
+  };
 
-        for(attr in this._attrs){
-            // only add non-empty attributes
-            if (!this._attrs[attr] || this._attrs[attr] === null){
-                continue;
-            }
+  this.onClickToSelectAnnotation = function () {
+    _self.dispatchEvent("onClickChangeSelectingAnnotation", {
+      graphID: _self.id || "",
+    });
+  };
 
-            // don't add the attributes that are added by osd viewer
-            if (this._addedAttributeNames.indexOf(attr) !== -1) {
-                continue;
-            }
-
-            attributeList[attr] = this._attrs[attr];
-        }
-
-        // read the ignored attributes after this._attrs, to ensure that the values in the input and output match
-        for (attr in this._ignoredAttrs) {
-            attributeList[attr] = this._ignoredAttrs[attr];
-        }
-
-        // add the attributes in sorted order
-        Object.keys(attributeList).sort().forEach(function (key) {
-            rst += (key + '="' + attributeList[key] + '" ');
-        });
-
-        rst += "></" + tag + ">";
-        return rst;
+  this.onMouseoverShowTooltip = function () {
+    if (_self.isDrawing) {
+      return;
     }
 
-    this.onClickToSelectAnnotation = function(){
-        _self.dispatchEvent("onClickChangeSelectingAnnotation", {
-            graphID : _self.id || ""
-        });
-    };
+    _self.dispatchEvent("onMouseoverShowTooltip", {
+      x: d3.event.pageX,
+      y: d3.event.pageY,
+    });
+  };
 
-    this.onMouseoverShowTooltip = function(){
+  this.onMousemoveShowTooltip = function () {
+    if (_self.isDrawing) {
+      return;
+    }
 
-        if(_self.isDrawing){
-            return;
-        }
+    _self.dispatchEvent("onMousemoveShowTooltip", {
+      x: d3.event.pageX,
+      y: d3.event.pageY,
+    });
+  };
 
-        _self.dispatchEvent("onMouseoverShowTooltip", {
-            x : d3.event.pageX,
-            y : d3.event.pageY
-        })
-    };
+  this.onMouseoutHideTooltip = function () {
+    if (_self.isDrawing) {
+      return;
+    }
 
-    this.onMousemoveShowTooltip = function(){
-        if(_self.isDrawing){
-            return;
-        }
-
-        _self.dispatchEvent("onMousemoveShowTooltip", {
-            x : d3.event.pageX,
-            y : d3.event.pageY
-        })
-    };
-
-    this.onMouseoutHideTooltip = function(){
-        if(_self.isDrawing){
-            return;
-        }
-
-        _self.dispatchEvent("onMouseoutHideTooltip");
-    };
+    _self.dispatchEvent("onMouseoutHideTooltip");
+  };
 }
 
-Base.prototype.dispatchEvent = function(type, data){
-    this.parent.dispatchEvent(type, data);
-}
+Base.prototype.dispatchEvent = function (type, data) {
+  this.parent.dispatchEvent(type, data);
+};
 
-Base.prototype.setDrawing = function(isDrawing){
-    this.isDrawing = isDrawing;
-}
+Base.prototype.setDrawing = function (isDrawing) {
+  this.isDrawing = isDrawing;
+};
 
-Base.prototype.setupDrawingAttrs = function(attrs){
+Base.prototype.setupDrawingAttrs = function (attrs) {
+  this.setDrawing(true);
 
-    this.setDrawing(true);
+  if (attrs) {
+    this.setAttributesByJSON(attrs);
+  }
 
-    if(attrs){
-        this.setAttributesByJSON(attrs);
-    };
+  this.renderSVG();
+};
 
-    this.renderSVG();
-}
+Base.prototype.getAttribute = function (attr) {
+  if (this._attrs.hasOwnProperty(attr)) {
+    return this._attrs[attr];
+  } else {
+    return null;
+  }
+};
 
-Base.prototype.getAttribute = function(attr){
-    if(this._attrs.hasOwnProperty(attr)){
-        return this._attrs[attr];
-    }
-    else{
-        return null;
-    }
-}
+Base.prototype.getAttributes = function (attrs) {
+  var attr,
+    resAttr = {};
 
-Base.prototype.getAttributes = function(attrs){
-    var attr,
-        resAttr = {};
+  if (attrs.length > 0) {
+    attrs.forEach(function (attr) {
+      if (this._attrs.hasOwnProperty(attr)) {
+        resAttr[attr] = this._attrs[attr];
+      }
+    });
+    return resAttr;
+  } else {
+    return this._attrs;
+  }
+};
 
-    if(attrs.length > 0){
-        attrs.forEach(function(attr){
-            if(this._attrs.hasOwnProperty(attr)){
-                resAttr[attr] = this._attrs[attr];
-            };
-        })
-        return resAttr;
-    }
-    else{
-        return this._attrs;
-    }
-}
+Base.prototype.highlight = function (highlightAttrs) {
+  for (var attr in highlightAttrs) {
+    this.svg.attr(attr, highlightAttrs[attr]);
+  }
+};
 
-Base.prototype.highlight = function(highlightAttrs){
-    for(var attr in highlightAttrs){
-        this.svg.attr(attr, highlightAttrs[attr]);
-    }
-}
+Base.prototype.renderSVG = function (annotationType) {
+  var attr,
+    value,
+    strokeScale = this.parent.getStrokeScale() || 1;
 
-Base.prototype.renderSVG = function(){
-
-    var attr,
-        value,
-        strokeScale = this.parent.getStrokeScale() || 1;
-
-    if(this.svg == null){
-        this.svg = this.parent.svg
-            .append(this._tag)
-            .attr("class", "annotation")
-
-        this.svg.on("mouseover", this.onMouseoverShowTooltip)
-            .on("mousemove", this.onMousemoveShowTooltip)
-            .on("mouseout", this.onMouseoutHideTooltip)
-            .on('click', this.onClickToSelectAnnotation);
-
-        // prevent the default behavior of osd by adding an empty click handler
-        new OpenSeadragon.MouseTracker({
-            element: this.svg.node(),
-            clickHandler: function (e) {
-                // intentially left empy. we just want to prevent the default behavior (zoom)
-            }
-        });
-    }
-
-    // add all the attributes
-    for(attr in this._attrs){
-        value = this._attrs[attr];
-        if (attr === "stroke-width") {
-            // TODO what if the value is not in pixel? (it can be pixel)
-            value = (parseFloat(value) || 1) * strokeScale;
-        }
-        this.svg.attr(attr, value);
-    }
-}
-
-Base.prototype.setAttributesByJSON = function(attrs){
-    var attr,
-        value,
-        discardedAttributes = ["id", "style"];
-
-    for(attr in attrs){
-        if (!attr || !attrs.hasOwnProperty(attr) || discardedAttributes.indexOf(attr) != -1) {
-            continue;
-        }
-
-        value = attrs[attr];
-
-        // if it's any of the attributes that we should ignore
-        if (!(attr in this._attrs) || this._addedAttributeNames.indexOf(attr) !== -1) {
-            this._ignoredAttrs[attr] = value;
-        } else {
-            this._attrs[attr] = value;
-        }
-    }
-
-    // update the stroke in the group
-    this.parent.setGroupStrokeByAnnotation(this);
-}
-
-Base.prototype.unHighlight = function(){
-    var strokeScale = this.parent.getStrokeScale() || 1;
-    var strokeWidth = parseFloat(this._attrs["stroke-width"]) || 1;
+  if (this.svg == null) {
+    this.svg = this.parent.svg.append(this._tag).attr("class", "annotation");
 
     this.svg
-        .attr("fill", this._attrs["fill"] || "")
-        .attr("stroke", this._attrs["stroke"] || "")
-        .attr("stroke-width", strokeWidth * strokeScale)
-}
+      .on("mouseover", this.onMouseoverShowTooltip)
+      .on("mousemove", this.onMousemoveShowTooltip)
+      .on("mouseout", this.onMouseoutHideTooltip)
+      .on("click", this.onClickToSelectAnnotation);
 
-Base.prototype.unbind = function(){
+    // prevent the default behavior of osd by adding an empty click handler
+    new OpenSeadragon.MouseTracker({
+      element: this.svg.node(),
+      clickHandler: function (e) {
+        // intentially left empy. we just want to prevent the default behavior (zoom)
+      },
+    });
+  }
 
-    if(this.svg == null){
-        this.svg.on("mouseover", null)
-            .on("mousemove", null)
-            .on("mouseout", null)
-            .on('click', null);
+  // add all the attributes
+  for (attr in this._attrs) {
+    // We skip the marker-end attribute if the annotation is not arrow line
+    if (attr == "marker-end" && annotationType !== "arrowline") {
+      continue;
     }
-}
+    value = this._attrs[attr];
+    if (attr === "stroke-width") {
+      // TODO what if the value is not in pixel? (it can be pixel)
+      value = (parseFloat(value) || 1) * strokeScale;
+    }
+    this.svg.attr(attr, value);
+  }
+};
+
+Base.prototype.setAttributesByJSON = function (attrs) {
+  var attr,
+    value,
+    discardedAttributes = ["id", "style"];
+
+  for (attr in attrs) {
+    if (
+      !attr ||
+      !attrs.hasOwnProperty(attr) ||
+      discardedAttributes.indexOf(attr) != -1
+    ) {
+      continue;
+    }
+
+    value = attrs[attr];
+
+    // if it's any of the attributes that we should ignore
+    if (
+      !(attr in this._attrs) ||
+      this._addedAttributeNames.indexOf(attr) !== -1
+    ) {
+      this._ignoredAttrs[attr] = value;
+    } else {
+      this._attrs[attr] = value;
+    }
+  }
+
+  // update the stroke in the group
+  this.parent.setGroupStrokeByAnnotation(this);
+};
+
+Base.prototype.unHighlight = function () {
+  var strokeScale = this.parent.getStrokeScale() || 1;
+  var strokeWidth = parseFloat(this._attrs["stroke-width"]) || 1;
+
+  this.svg
+    .attr("fill", this._attrs["fill"] || "")
+    .attr("stroke", this._attrs["stroke"] || "")
+    .attr("stroke-width", strokeWidth * strokeScale);
+};
+
+Base.prototype.unbind = function () {
+  if (this.svg == null) {
+    this.svg
+      .on("mouseover", null)
+      .on("mousemove", null)
+      .on("mouseout", null)
+      .on("click", null);
+  }
+};

--- a/js/viewer/annotation/line.js
+++ b/js/viewer/annotation/line.js
@@ -1,38 +1,35 @@
 function Line(attrs) {
-
-	attrs = attrs ? attrs : {};
-	Base.call(this, attrs);
-	this._tag = "line";
-	this._attrs["x1"] = attrs["x1"] || null;
-	this._attrs["y1"] = attrs["y1"] || null;
-	this._attrs["x2"] = attrs["x2"] || null;
-	this._attrs["y2"] = attrs["y2"] || null;
-	this.svg = null;
-};
+  attrs = attrs ? attrs : {};
+  Base.call(this, attrs);
+  this._tag = "line";
+  this._attrs["x1"] = attrs["x1"] || null;
+  this._attrs["y1"] = attrs["y1"] || null;
+  this._attrs["x2"] = attrs["x2"] || null;
+  this._attrs["y2"] = attrs["y2"] || null;
+  this.svg = null;
+}
 
 Line.prototype = Object.create(Base.prototype);
 Line.prototype.constructor = Line;
 
-
 Line.prototype.insertPoint = function (point) {
-	var _self = this;
-	var updateAttrs = {};
-	
-	if (_self._attrs.x1 == null || _self._attrs.y1 == null) {
-		// when the line is first added both the start and end point are assigned the same.
-		updateAttrs = {
-			x1: point.x,
-			y1: point.y,
-			x2: point.x,
-			y2: point.y
-		};
-	}
-	else {
-		updateAttrs = {
-			x2: point.x,
-			y2: point.y
-		}
-	}
-	_self.setAttributesByJSON(updateAttrs);
-	_self.renderSVG();
-}
+  var _self = this;
+  var updateAttrs = {};
+
+  if (_self._attrs.x1 == null || _self._attrs.y1 == null) {
+    // when the line is first added both the start and end point are assigned the same.
+    updateAttrs = {
+      x1: point.x,
+      y1: point.y,
+      x2: point.x,
+      y2: point.y,
+    };
+  } else {
+    updateAttrs = {
+      x2: point.x,
+      y2: point.y,
+    };
+  }
+  _self.setAttributesByJSON(updateAttrs);
+  _self.renderSVG();
+};

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -1,1457 +1,1591 @@
 function Viewer(parent, config) {
+  const modes = {
+    VIEW: "VIEW",
+    ERASE_ANNOTATIONS: "ERASE_ANNOTATIONS",
+  };
 
-    const modes = {
-        "VIEW" : 'VIEW',
-        "ERASE_ANNOTATIONS" : 'ERASE_ANNOTATIONS'
+  var _self = this;
+
+  this._utils = null;
+  this.config = config;
+
+  this.parent = parent;
+  this.channels = {};
+  this.filters = {}; // For filters of multiple channels.
+  this.current = {
+    svgID: "",
+    groupID: "",
+  };
+  this.mouseTrackers = [];
+  this.mode = modes.VIEW;
+  this.isInitLoad = false;
+  this.osd = null;
+  this.tooltipElem = null;
+  this.svg = null;
+  this.svgCollection = {};
+  this.scale = null;
+  this.strokeScale = 1;
+  this.strokeWidthScale = null;
+  this.strokeMinScale = 1.5;
+  this.strokeMaxScale = 3.5;
+  this.svgNotPresent = false;
+  this.stayInsideImage = true;
+
+  this.svgFiles = {};
+
+  // This boolean variable controls whether to show Channel names over the OSD or not.
+  this._showChannelNamesOverlay = false;
+
+  // Init
+  this.init = function (utils, params) {
+    if (!OpenSeadragon || !utils) {
+      return null;
+    }
+    this._utils = utils;
+
+    // Add each image source into Openseadragon viewer
+    if (!params.isProcessed) {
+      this.parameters = this._utils.processParams(params);
+    } else {
+      this.parameters = params;
     }
 
-    var _self = this;
+    // configure osd
+    this.osd = OpenSeadragon(this.config.osd);
 
-    this._utils = null;
-    this.config = config;
+    // show spinner while initializing the page
+    this.resetSpinner(true);
 
-    this.parent = parent;
-    this.channels = {};
-    this.filters = {} // For filters of multiple channels.
-    this.current = {
-        svgID : "",
-        groupID : ""
-    };
-    this.mouseTrackers = [];
-    this.mode = modes.VIEW;
-    this.isInitLoad = false;
-    this.osd = null;
-    this.tooltipElem = null;
-    this.svg = null;
-    this.svgCollection = {};
-    this.scale = null;
-    this.strokeScale = 1;
-    this.strokeWidthScale = null;
-    this.strokeMinScale = 1.5;
-    this.strokeMaxScale = 3.5;
-    this.svgNotPresent = false;
-    this.stayInsideImage = true;
+    // add the scalebar (might change based on the images)
+    this.osd.scalebar(this.config.scalebar);
 
-    this.svgFiles = {};
+    // load the images
+    console.log("channels:", _self.parameters.channels);
+    this.loadImages(this.parameters.mainImage);
 
-    // This boolean variable controls whether to show Channel names over the OSD or not.
-    this._showChannelNamesOverlay = false;
+    // Add a SVG container to contain annotations
+    this.svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    this.svg.setAttribute("id", this.config.annotation.id);
+    this.osd.canvas.append(this.svg);
 
-    // Init
-    this.init = function (utils, params) {
+    // channel names overlay
+    var overlayContainer = document.createElement("div");
+    overlayContainer.setAttribute("id", "channel-names-overlay-container");
+    this.osd.canvas.append(overlayContainer);
 
-        if (!OpenSeadragon || !utils) {
-            return null;
+    // whether we want to show the image color histogram or not
+    this.config.osd.showHistogram =
+      this.config.osd.showHistogram || this.parameters.showHistogram;
+    if (this.config.osd.showHistogram) {
+      this.osd.initializeColorHistogram();
+    }
+
+    // after each resize, make sure svgs are properly positioned
+    this.osd.addHandler("resize", this.resizeSVG);
+
+    // after each change, make sure svgs are properly positioned
+    this.osd.addHandler("animation", this.resizeSVG);
+
+    // zoom on double click
+    this.osd.addHandler("canvas-double-click", this.zoomIn.bind(this));
+
+    // inform the client if any of the images failed to load
+    this.osd.world.addHandler("add-item-failed", function (event) {
+      console.error("Failed to add an item to osd", event);
+      _self.resetSpinner();
+      _self.dispatchEvent("mainImageLoadFailed", {});
+    });
+
+    // the finalizing tasks after images are load
+    var zPlaneInitialized = false;
+    this.osd.world.addHandler("add-item", function (event) {
+      // we need the aspect ratio, so we have to wait for at least one image
+      if (!zPlaneInitialized) {
+        zPlaneInitialized = true;
+
+        // if we're showing a multi-z view, we should start it
+        if (_self.parameters.zPlane && _self.parameters.zPlane.count > 1) {
+          var imageSize = event.item.getContentSize();
+          var canUpdate =
+            _self.parameters.acls &&
+            _self.parameters.acls.mainImage &&
+            _self.parameters.acls.mainImage.canUpdateDefaultZIndex;
+
+          _self.dispatchEvent("initializeZPlaneList", {
+            totalCount: _self.parameters.zPlane.count,
+            minZIndex: _self.parameters.zPlane.minZIndex,
+            maxZIndex: _self.parameters.zPlane.maxZIndex,
+            mainImageZIndex: _self.parameters.mainImage.zIndex,
+            mainImageWidth: imageSize.x,
+            mainImageHeight: imageSize.y,
+            canUpdateDefaultZIndex: canUpdate,
+          });
         }
-        this._utils = utils;
+      }
 
-        // Add each image source into Openseadragon viewer
-        if (!params.isProcessed) {
-            this.parameters = this._utils.processParams(params);
-        } else {
-            this.parameters = params;
+      // display a spinner while the images are loading
+      event.item.addHandler("fully-loaded-change", function () {
+        // make sure all the images are added
+        if (
+          Object.keys(_self.channels).length != _self.osd.world.getItemCount()
+        ) {
+          _self.resetSpinner(true);
+          return;
         }
 
-        // configure osd
-        this.osd = OpenSeadragon(this.config.osd);
-
-        // show spinner while initializing the page
-        this.resetSpinner(true);
-
-        // add the scalebar (might change based on the images)
-        this.osd.scalebar(this.config.scalebar);
-
-        // load the images
-        console.log('channels:', _self.parameters.channels);
-        this.loadImages(this.parameters.mainImage);
-
-        // Add a SVG container to contain annotations
-        this.svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-        this.svg.setAttribute("id", this.config.annotation.id);
-        this.osd.canvas.append(this.svg);
-
-        // channel names overlay
-        var overlayContainer = document.createElement("div");
-        overlayContainer.setAttribute("id", "channel-names-overlay-container");
-        this.osd.canvas.append(overlayContainer);
-
-        // whether we want to show the image color histogram or not
-        this.config.osd.showHistogram = this.config.osd.showHistogram || this.parameters.showHistogram;
-        if (this.config.osd.showHistogram) {
-            this.osd.initializeColorHistogram();
+        // make sure all the tiles are fully loaded
+        for (var i = 0; i < _self.osd.world.getItemCount(); i++) {
+          if (
+            _self.osd.world.getItemAt(i).opacity != 0 &&
+            !_self.osd.world.getItemAt(i).getFullyLoaded()
+          ) {
+            _self.resetSpinner(true);
+            return;
+          }
         }
 
-        // after each resize, make sure svgs are properly positioned
-        this.osd.addHandler('resize', this.resizeSVG);
+        // hide the spinner (all images are added and loaded)
+        _self.resetSpinner();
 
-        // after each change, make sure svgs are properly positioned
-        this.osd.addHandler('animation', this.resizeSVG);
+        if (_self.config.osd.showHistogram) {
+          _self.osd.drawColorHistogram();
+        }
+      });
 
-        // zoom on double click
-        this.osd.addHandler('canvas-double-click', this.zoomIn.bind(this));
+      // when all the images are added
+      if (
+        Object.keys(_self.channels).length == _self.osd.world.getItemCount()
+      ) {
+        // finalize loading
+        _self.loadAfterOSDInit();
 
-        // inform the client if any of the images failed to load
-        this.osd.world.addHandler('add-item-failed', function(event) {
-            console.error("Failed to add an item to osd", event);
-            _self.resetSpinner();
-            _self.dispatchEvent('mainImageLoadFailed', {});
-        });
+        // make sure the scalebar is correct
+        var meterScaleInPixels = _self.parameters.meterScaleInPixels;
+        if (meterScaleInPixels) {
+          _self.resetScalebar(meterScaleInPixels);
+        }
 
-        // the finalizing tasks after images are load
-        var zPlaneInitialized = false;
-        this.osd.world.addHandler('add-item', function(event) {
-            // we need the aspect ratio, so we have to wait for at least one image
-            if (!zPlaneInitialized) {
-                zPlaneInitialized = true;
+        // apply the intiial channel filters
+        for (var key in _self.channels) {
+          var channel = _self.channels[key];
+          _self.setItemChannel({
+            id: channel.id,
+            init: true,
+          });
+        }
 
-                // if we're showing a multi-z view, we should start it
-                if (_self.parameters.zPlane && _self.parameters.zPlane.count > 1) {
-                    var imageSize = event.item.getContentSize()
-                    var canUpdate = _self.parameters.acls && _self.parameters.acls.mainImage
-                                    && _self.parameters.acls.mainImage.canUpdateDefaultZIndex;
-
-                    _self.dispatchEvent('initializeZPlaneList', {
-                        "totalCount": _self.parameters.zPlane.count,
-                        "minZIndex": _self.parameters.zPlane.minZIndex,
-                        "maxZIndex": _self.parameters.zPlane.maxZIndex,
-                        "mainImageZIndex": _self.parameters.mainImage.zIndex,
-                        "mainImageWidth": imageSize.x,
-                        "mainImageHeight": imageSize.y,
-                        "canUpdateDefaultZIndex": canUpdate
-                    });
-                }
-            }
-
-            // display a spinner while the images are loading
-            event.item.addHandler('fully-loaded-change', function() {
-                // make sure all the images are added
-                if (Object.keys(_self.channels).length != _self.osd.world.getItemCount()) {
-                    _self.resetSpinner(true);
-                    return;
-                }
-
-                // make sure all the tiles are fully loaded
-                for (var i = 0; i < _self.osd.world.getItemCount(); i++) {
-                    if (_self.osd.world.getItemAt(i).opacity != 0 && !_self.osd.world.getItemAt(i).getFullyLoaded()) {
-                        _self.resetSpinner(true);
-                        return;
-                    }
-                }
-
-                // hide the spinner (all images are added and loaded)
-                _self.resetSpinner();
-
-                if (_self.config.osd.showHistogram) {
-                    _self.osd.drawColorHistogram();
-                }
-            });
-
-            // when all the images are added
-            if(Object.keys(_self.channels).length == _self.osd.world.getItemCount()){
-                // finalize loading
-                _self.loadAfterOSDInit();
-
-                // make sure the scalebar is correct
-                var meterScaleInPixels = _self.parameters.meterScaleInPixels;
-                if (meterScaleInPixels) {
-                  _self.resetScalebar(meterScaleInPixels);
-                }
-
-                // apply the intiial channel filters
-                for(var key in _self.channels){
-                    var channel = _self.channels[key];
-                    _self.setItemChannel({
-                        id : channel.id,
-                        init: true
-                    });
-                }
-                
-                // render the channel names
-                _self.renderChannelNamesOverlay();
-
-                // resize sensor for the container
-                _self._containerResizeSensor = null;
-                new ResizeSensor(document.getElementById('container'), function () {
-                    clearTimeout(_self._containerResizeSensor);
-                    _self._containerResizeSensor = setTimeout(function () {
-                        // make sure the names can fit the new container
-                        _self.renderChannelNamesOverlay();
-                    }, 200);
-                });
-            }
-        });
-    };
-
-    // This function toggles _showChannelNamesOverlay
-    this.toggleChannelNamesOverlay = function() {
-        _self._showChannelNamesOverlay = !_self._showChannelNamesOverlay;
+        // render the channel names
         _self.renderChannelNamesOverlay();
+
+        // resize sensor for the container
+        _self._containerResizeSensor = null;
+        new ResizeSensor(document.getElementById("container"), function () {
+          clearTimeout(_self._containerResizeSensor);
+          _self._containerResizeSensor = setTimeout(function () {
+            // make sure the names can fit the new container
+            _self.renderChannelNamesOverlay();
+          }, 200);
+        });
+      }
+    });
+  };
+
+  // This function toggles _showChannelNamesOverlay
+  this.toggleChannelNamesOverlay = function () {
+    _self._showChannelNamesOverlay = !_self._showChannelNamesOverlay;
+    _self.renderChannelNamesOverlay();
+  };
+
+  /**
+   * This function renders the Channel names on the OSD, inside the overlay container
+   * Since we have to find the proper fontsize and truncated name, we cannot just
+   * update one name while not affecting the rest. so each time that one channel
+   * is toggled, we have to do the logic from start.
+   */
+  this.renderChannelNamesOverlay = function () {
+    // console.log("calling channel render");
+    var overlayContainer = document.getElementById(
+      "channel-names-overlay-container"
+    );
+
+    // the channel names are shown based on the value of _showChannelNamesOverlay
+    // we're not showing the overlay for images with just one channel
+    if (!_self._showChannelNamesOverlay) {
+      overlayContainer.style.display = "none";
+      return;
+    } else {
+      overlayContainer.style.display = "block";
     }
 
-    /**
-     * This function renders the Channel names on the OSD, inside the overlay container
-     * Since we have to find the proper fontsize and truncated name, we cannot just 
-     * update one name while not affecting the rest. so each time that one channel
-     * is toggled, we have to do the logic from start.
-     */
-    this.renderChannelNamesOverlay = function() {
-        // console.log("calling channel render");
-        var overlayContainer = document.getElementById("channel-names-overlay-container");
+    var divWidth = overlayContainer.offsetWidth;
 
-        // the channel names are shown based on the value of _showChannelNamesOverlay
-        // we're not showing the overlay for images with just one channel
-        if (!_self._showChannelNamesOverlay) {
-            overlayContainer.style.display = 'none';
-            return;
+    var constants = window.OSDViewer.constants.CHANNEL_NAMES_OVERLAY_CONFIG;
+    var channelArray = [];
+
+    for (id in _self.channels) {
+      if (_self.channels[id].isDisplay) {
+        // TODO channel data should just be an object, it's a lot easier to read that way
+        channelArray.push([
+          _self.channels[id].name,
+          _self.channels[id].getOverlayColor(),
+          id,
+        ]);
+      }
+    }
+
+    var fontSize = _self._utils.channelNamesOverlay.getFontSize(
+      channelArray,
+      divWidth
+    );
+
+    overlayContainer.style.fontSize = fontSize + "pt";
+    overlayContainer.innerHTML = "";
+
+    // update the channel names so that they can fit into the given space
+    for (let i = 0; i < channelArray.length; i++) {
+      channelArray[i][0] =
+        _self._utils.channelNamesOverlay.getUpdatedChannelName(
+          channelArray[i][0],
+          divWidth,
+          fontSize
+        );
+    }
+
+    var start = 0,
+      end = 0,
+      line = 0;
+    while (start < channelArray.length && line < constants.MAX_LINES) {
+      var lineContent = document.createElement("div");
+      lineContent.classList.add("container-line");
+
+      // find how many names can fit in a single line
+      var lineWidth = 0;
+      while (
+        end < channelArray.length &&
+        lineWidth + _self._utils.getTextWidth(channelArray[end][0], fontSize) <
+          constants.USABLE_AREA * divWidth
+      ) {
+        lineWidth +=
+          _self._utils.getTextWidth(channelArray[end][0], fontSize) + 40;
+        var spanContent = document.createElement("span");
+        spanContent.classList.add("channel-name");
+        spanContent.style.color = channelArray[end][1];
+        spanContent.innerHTML = channelArray[end][0];
+        lineContent.appendChild(spanContent);
+
+        // attaching the element to the channel object, so we can just update its color
+        // instead of creating the overlay again
+        _self.channels[channelArray[end][2]].setOverlayElement(spanContent);
+
+        end += 1;
+      }
+
+      var hasMore = true;
+      if (end >= channelArray.length) {
+        hasMore = false;
+      }
+
+      // Add the names to the line
+      line += 1;
+      start = end;
+      if (line == constants.MAX_LINES && hasMore) {
+        var spanContent = document.createElement("span");
+        spanContent.classList.add("channel-name");
+        spanContent.innerHTML = "...";
+        lineContent.appendChild(spanContent);
+      }
+
+      overlayContainer.appendChild(lineContent);
+    }
+  };
+
+  // Add new term
+  this.addNewTerm = function (data) {
+    if (!this.osd || !this.osd.world.getItemAt(0)) {
+      return;
+    }
+
+    var svg = null,
+      id = null;
+    contentSize = {};
+
+    // if svgID is exist
+    if (this.svgCollection.hasOwnProperty(data.svgID)) {
+      this.dispatchSVGEvent("addNewGroup", data);
+    }
+    // create a new svg
+    else {
+      contentSize = this.osd.world.getItemAt(0).getContentSize();
+      svg = new AnnotationSVG(this, data.svgID, contentSize.x, contentSize.y);
+      svg.render();
+      svg.createAnnotationGroup(data.groupID, data.anatomy, data.description); // create a new group
+      this.svgCollection[data.svgID] = svg; // add the new svg into collection
+      this.resizeSVG(); // resize the svg to align with current OSD viewport
+    }
+  };
+  // Build a tilesource object for Openseadragon Config
+  this.buildTileSource = function (xmlDoc, imgPath) {
+    var tileSource = {};
+    tileSource.height = parseInt(xmlDoc.getAttribute("height"));
+    tileSource.width = parseInt(xmlDoc.getAttribute("width"));
+    tileSource.tileWidth = parseInt(xmlDoc.getAttribute("tileWidth"));
+    tileSource.tileHeight = parseInt(xmlDoc.getAttribute("tileHeight"));
+    tileSource.levelscale = parseInt(xmlDoc.getAttribute("levelScale"));
+    tileSource.minLevel = parseInt(xmlDoc.getAttribute("minLevel"));
+    tileSource.maxLevel = parseInt(xmlDoc.getAttribute("maxLevel"));
+    tileSource.overlap = parseInt(xmlDoc.getAttribute("overlap")) || 0;
+    tileSource.channelName = xmlDoc.getAttribute("channelName");
+    tileSource.channelAlpha = +xmlDoc.getAttribute("channelDefaultAlpha");
+    tileSource.pseudoColor = xmlDoc.getAttribute("channelDefaultRGB");
+    tileSource.dir = xmlDoc.getAttribute("data");
+    tileSource.format = xmlDoc.getAttribute("format") || "jpg";
+    tileSource.meterScaleInPixels = parseFloat(
+      xmlDoc.getAttribute("meterScaleInPixels")
+    );
+    tileSource.minValue = parseFloat(xmlDoc.getAttribute("minValue")) || 0.0;
+    tileSource.maxValue = parseFloat(xmlDoc.getAttribute("maxValue")) || 0.0;
+    tileSource.imgPath = imgPath;
+    tileSource.getLevelScale = function (level) {
+      var levelScaleCache = {},
+        i;
+      for (i = 0; i <= tileSource.maxLevel; i++) {
+        levelScaleCache[i] =
+          1 / Math.pow(tileSource.levelscale, tileSource.maxLevel - i);
+      }
+      tileSource.getLevelScale = function (_level) {
+        return levelScaleCache[_level];
+      };
+      return tileSource.getLevelScale(level);
+    };
+    tileSource.getTileUrl = function (level, x, y) {
+      var t =
+        tileSource.imgPath +
+        "/" +
+        level +
+        "/" +
+        x +
+        "_" +
+        y +
+        "." +
+        tileSource.format;
+      return t;
+    };
+    return tileSource;
+  };
+
+  // Set current selecting annotation
+  this.changeSelectingAnnotation = function (data) {
+    if (
+      this.current.svgID == data.svgID &&
+      this.current.groupID == data.groupID
+    ) {
+      if (this.svgCollection.hasOwnProperty(this.current.svgID)) {
+        this.svgCollection[this.current.svgID].changeSelectedGroup(
+          this.current
+        );
+      }
+      this.current.svgID = "";
+      this.current.groupID = "";
+    } else if (this.svgCollection.hasOwnProperty(data.svgID)) {
+      // if(data.x1 && data.x2 && data.y1 && data.y2){
+      //     this.zoomInRectViewport(data)
+      // }
+      if (this.svgCollection.hasOwnProperty(this.current.svgID)) {
+        this.svgCollection[this.current.svgID].changeSelectedGroup(
+          this.current
+        );
+      }
+      this.current.svgID = data.svgID;
+      this.current.groupID = data.groupID;
+
+      this.svgCollection[data.svgID].changeSelectedGroup(data);
+      this.svg.append(this.svgCollection[data.svgID].svg);
+    }
+  };
+
+  // Change all SVGs annotations visibility
+  this.changeAllAnnotationVisibility = function (isDisplay) {
+    for (var svgID in this.svgCollection) {
+      this.svgCollection[svgID].changeAllVisibility(isDisplay);
+    }
+  };
+
+  // Change scale stroke width
+  this.changeStrokeScale = function (strokeScale) {
+    this.strokeScale = strokeScale;
+    for (var svgID in this.svgCollection) {
+      this.svgCollection[svgID].changeStrokeScale();
+    }
+  };
+
+  // Change SVG ID
+  this.changeSVGId = function (data) {
+    // Change existing SVG id from the collection
+    if (this.svgCollection.hasOwnProperty(data.svgID)) {
+      var prevSVG = this.svgCollection[data.svgID];
+      prevSVG.updateID(data.newSvgID);
+
+      this.svgCollection[data.newGroupID] = prevGroup;
+
+      // update the current svg id if it's also the changing svg id
+      if (this.current.svgID === data.svgID) {
+        this.current.svgID = data.newSvgID;
+      }
+
+      delete this.svgCollection[data.svgID];
+
+      // continue to dispatch to parent to handle the necessary updates
+      this.dispatchEvent("updateGroupInfo", data);
+    }
+  };
+
+  // Handle events from children/ Dispatch events to toolbar
+  this.dispatchEvent = function (type, data) {
+    switch (type) {
+      /**
+       * [Handle events from children]
+       */
+      // Show group tooltip when mouse over
+      case "onMouseoverShowTooltip":
+        this.onMouseoverShowTooltip(data);
+        break;
+      // Adjust tooltip location when mouse move
+      case "onMousemoveShowTooltip":
+        this.onMousemoveShowTooltip(data);
+        break;
+      // Remove tooltip and border when mouse out of the svg
+      case "onMouseoutHideTooltip":
+        this.onMouseoutHideTooltip();
+        break;
+      // Create mousetracker to begin drawing
+      case "onDrawingBegin":
+        // alert("view start drawing")
+        var tracker = new OpenSeadragon.MouseTracker({
+          element: _self.svg,
+          dragHandler: this.onMouseDragToDraw,
+          dragEndHandler: this.onMouseDragToDrawEnd,
+          userData: data,
+        });
+        _self.mouseTrackers.push(tracker);
+        break;
+      case "updateSVGId":
+        var prevSVG = this.svgCollection[data.svgID];
+        // update the current object -> change svg ID if matches the old one
+        if (this.current.svgID === data.svgID) {
+          this.current.svgID = data.newSvgID;
+        }
+        if (prevSVG) {
+          this.svgCollection[data.newSvgID] = prevSVG;
+          delete this.svgCollection[data.svgID];
+        }
+
+        this.parent.dispatchEvent("updateSVGId", data);
+        break;
+      case "updateGroupInfo":
+        // update the current object -> change group ID if matches the old one
+        if (this.current.groupID === data.groupID) {
+          this.current.groupID = data.newGroupID;
+        }
+        this.parent.dispatchEvent("updateGroupInfo", data);
+        break;
+      /**
+       * [Dispatch events to App]
+       */
+      // Change current selected annotation group from toolbar
+      case "onClickChangeSelectingAnnotation":
+        if (_self.mode == modes.ERASE_ANNOTATIONS) {
+          this.dispatchSVGEvent("removeAnnotationByGraphID", {
+            svgID: data.svgID,
+            groupID: data.groupID,
+            graphID: data.graphID,
+          });
+        } else if (_self.mode == modes.VIEW) {
+          this.changeSelectingAnnotation(data);
+          this.parent.dispatchEvent(type, {
+            svgID: data.svgID,
+            groupID: data.groupID,
+          });
+        }
+        break;
+      default:
+        this.parent.dispatchEvent(type, data);
+        break;
+    }
+  };
+
+  // Dispatch events to SVG objects
+  this.dispatchSVGEvent = function (type, data) {
+    if (!this.svgCollection.hasOwnProperty(data.svgID)) {
+      return;
+    }
+
+    var svg = this.svgCollection[data.svgID];
+
+    switch (type) {
+      // Add a new group
+      case "addNewGroup":
+        svg.createAnnotationGroup(data.groupID, data.anatomy, data.description);
+        break;
+      // Change an annotation group's visibility
+      case "changeAnnotationVisibility":
+        svg.changeVisibility(data);
+        break;
+      // Change stroke scale
+      case "changeStrokeScale":
+        svg.changeStrokeScale(data);
+        break;
+      // Change SVG ID
+      case "changeSVGId":
+        svg.changeSVGId(data);
+        break;
+      // Change group information:
+      case "changeGroupInfo":
+        svg.changeGroupInfo(data);
+        break;
+      // Drawing annotation on the SVG
+      case "drawingStart":
+        svg.createAnnotationObject(data.groupID, data.type, data.attrs);
+        break;
+      // Change the color of the annotation
+      case "drawingStrokeChanged":
+        svg.changeDrawingStroke(data);
+        break;
+      // Change current selected annotation group
+      case "highlightAnnotation":
+        this.changeSelectingAnnotation(data);
+        break;
+      // Change all annotation groups visibility
+      case "changeAllVisibility":
+        svg.changeAllVisibility(data.isDisplay);
+        break;
+      // Remove annotation object from a group
+      case "removeAnnotationByGraphID":
+        svg.removeAnnotationByGraphID(data.groupID, data.graphID);
+        this.dispatchEvent("onMouseoutHideTooltip");
+        break;
+      // Set annotation groups attributes
+      case "setGroupAttributes":
+        svg.setGroupAttributes(data);
+        break;
+      default:
+        break;
+    }
+  };
+
+  // Draw annotation mode on -> only show the related annotation objects
+  this.drawAnnotationMode = function (data) {
+    // Check if the svg id exists
+    var svgID,
+      groupID,
+      isDisplay,
+      foundAMatch = false,
+      usedColors = [];
+    var mode = data.mode.toUpperCase();
+
+    var setStroke = data.setStroke === true;
+    delete data.setStroke;
+
+    // remove all current mouse trackers
+    this.removeMouseTrackers();
+
+    // Hide all annotation objects
+    for (svgID in this.svgCollection) {
+      if (mode == "ON") {
+        if (svgID == data.svgID) {
+          for (groupID in this.svgCollection[svgID].groups) {
+            // indicate whether we found a match or not
+            foundAMatch = foundAMatch || groupID == data.groupID;
+
+            // only show the matching group
+            isDisplay = groupID == data.groupID ? true : false;
+            this.svgCollection[svgID].groups[groupID].setDisplay(isDisplay);
+
+            // set the drawing tool stroke to be based on the group stroke
+            if (setStroke && groupID == data.groupID) {
+              data.stroke = this.svgCollection[svgID].groups[groupID].stroke[0];
+            }
+          }
         } else {
-            overlayContainer.style.display = 'block';
+          this.svgCollection[svgID].changeAllVisibility(false);
         }
-
-        var divWidth = overlayContainer.offsetWidth
-
-        var constants = window.OSDViewer.constants.CHANNEL_NAMES_OVERLAY_CONFIG
-        var channelArray = [];
-
-        for (id in _self.channels) {
-            if (_self.channels[id].isDisplay) {
-                // TODO channel data should just be an object, it's a lot easier to read that way
-                channelArray.push([_self.channels[id].name, _self.channels[id].getOverlayColor(), id])
-            }
-        }
-
-        var fontSize = _self._utils.channelNamesOverlay.getFontSize(channelArray, divWidth);
-        
-        overlayContainer.style.fontSize = fontSize + 'pt';
-        overlayContainer.innerHTML = "";
-
-        // update the channel names so that they can fit into the given space
-        for (let i = 0; i < channelArray.length; i++) {
-            channelArray[i][0] = _self._utils.channelNamesOverlay.getUpdatedChannelName(
-                channelArray[i][0], 
-                divWidth, 
-                fontSize
-            );
-        }
-
-        var start = 0, end = 0, line = 0;
-        while (start < channelArray.length && line < constants.MAX_LINES) {
-
-            var lineContent = document.createElement("div");
-            lineContent.classList.add('container-line');
-
-            // find how many names can fit in a single line
-            var lineWidth = 0
-            while (end < channelArray.length && lineWidth + _self._utils.getTextWidth(channelArray[end][0], fontSize) < constants.USABLE_AREA * divWidth) {
-                lineWidth += _self._utils.getTextWidth(channelArray[end][0], fontSize) + 40;
-                var spanContent = document.createElement('span');
-                spanContent.classList.add('channel-name');
-                spanContent.style.color = channelArray[end][1];
-                spanContent.innerHTML = channelArray[end][0];
-                lineContent.appendChild(spanContent);
-                
-                // attaching the element to the channel object, so we can just update its color
-                // instead of creating the overlay again
-                _self.channels[channelArray[end][2]].setOverlayElement(spanContent);
-
-                end += 1;
-            }
-
-            var hasMore = true;
-            if (end >= channelArray.length) {
-                hasMore = false
-            }
-
-            // Add the names to the line
-            line += 1;
-            start = end;
-            if (line == constants.MAX_LINES && hasMore) {
-                var spanContent = document.createElement('span');
-                spanContent.classList.add('channel-name');
-                spanContent.innerHTML = '...';
-                lineContent.appendChild(spanContent);
-            }
-
-            overlayContainer.appendChild(lineContent);
-        }
+      } else {
+        this.svgCollection[svgID].changeAllVisibility(true);
+      }
     }
 
-    // Add new term
-    this.addNewTerm = function(data){
-
-        if(!this.osd || !this.osd.world.getItemAt(0)){
-            return;
+    // if we didn't find a matching group, use a random stroke
+    if (setStroke && !foundAMatch) {
+      // TODO could be improved by incorporating it with the other loop
+      // find the colors that are used, to avoid duplicate colors
+      for (svgID in this.svgCollection) {
+        for (groupID in this.svgCollection[svgID].groups) {
+          usedColors = usedColors.concat(
+            this.svgCollection[svgID].groups[groupID].stroke
+          );
         }
-
-        var svg = null,
-            id = null;
-            contentSize = {};
-
-        // if svgID is exist
-        if(this.svgCollection.hasOwnProperty(data.svgID)){
-            this.dispatchSVGEvent("addNewGroup", data);
-        }
-        // create a new svg
-        else{
-            contentSize = this.osd.world.getItemAt(0).getContentSize();
-            svg = new AnnotationSVG(this, data.svgID, contentSize.x, contentSize.y);
-            svg.render();
-            svg.createAnnotationGroup(data.groupID, data.anatomy, data.description); // create a new group
-            this.svgCollection[data.svgID] = svg; // add the new svg into collection
-            this.resizeSVG(); // resize the svg to align with current OSD viewport
-        }
-
-    }
-    // Build a tilesource object for Openseadragon Config
-    this.buildTileSource = function (xmlDoc, imgPath) {
-
-        var tileSource = {};
-        tileSource.height = parseInt(xmlDoc.getAttribute("height"));
-        tileSource.width = parseInt(xmlDoc.getAttribute("width"));
-        tileSource.tileWidth = parseInt(xmlDoc.getAttribute("tileWidth"));
-        tileSource.tileHeight = parseInt(xmlDoc.getAttribute("tileHeight"));
-        tileSource.levelscale = parseInt(xmlDoc.getAttribute("levelScale"));
-        tileSource.minLevel = parseInt(xmlDoc.getAttribute("minLevel"));
-        tileSource.maxLevel = parseInt(xmlDoc.getAttribute("maxLevel"));
-        tileSource.overlap = parseInt(xmlDoc.getAttribute("overlap")) || 0;
-        tileSource.channelName = xmlDoc.getAttribute("channelName");
-        tileSource.channelAlpha = +xmlDoc.getAttribute("channelDefaultAlpha");
-        tileSource.pseudoColor = xmlDoc.getAttribute("channelDefaultRGB");
-        tileSource.dir = xmlDoc.getAttribute("data");
-        tileSource.format = xmlDoc.getAttribute("format") || "jpg";
-        tileSource.meterScaleInPixels = parseFloat(xmlDoc.getAttribute("meterScaleInPixels"));
-        tileSource.minValue = parseFloat(xmlDoc.getAttribute("minValue")) || 0.0;
-        tileSource.maxValue = parseFloat(xmlDoc.getAttribute("maxValue")) || 0.0;
-        tileSource.imgPath = imgPath;
-        tileSource.getLevelScale = function (level) {
-            var levelScaleCache = {}, i;
-            for (i = 0; i <= tileSource.maxLevel; i++) {
-                levelScaleCache[i] = 1 / Math.pow(tileSource.levelscale, tileSource.maxLevel - i);
-            }
-            tileSource.getLevelScale = function (_level) {
-                return levelScaleCache[_level];
-            };
-            return tileSource.getLevelScale(level);
-        };
-        tileSource.getTileUrl = function (level, x, y) {
-            var t = tileSource.imgPath + "/" + (level) + "/" + x + "_" + y + "." + tileSource.format;
-            return t;
-        };
-        return tileSource;
+      }
+      data.stroke = this._utils.generateColor(usedColors);
     }
 
-    // Set current selecting annotation
-    this.changeSelectingAnnotation = function (data) {
+    this.dispatchEvent("toggleDrawingTool", data);
+  };
 
-        if(this.current.svgID == data.svgID && this.current.groupID == data.groupID){
-            if(this.svgCollection.hasOwnProperty(this.current.svgID)){
-                this.svgCollection[this.current.svgID].changeSelectedGroup(this.current);
-            }
-            this.current.svgID = "";
-            this.current.groupID = "";
+  /**
+   * Export the displayed view of osd viewer to a jpg file.
+   * Apart from the osd canvas, it will also add the svg overlays
+   * This function will trigger a browser download after processing is done.
+   * The messages that will be displatched by this function:
+   *  - `downloadViewDone`: when download is done.
+   *  - `downloadViewError`: if we encounter an error.
+   *
+   * @param {String=} fileName - the name of the file that will be downloaded
+   */
+  this.exportViewToJPG = function (fileName) {
+    fileName = fileName
+      ? fileName + ".jpg"
+      : "osd_" + Date.parse(new Date()) + ".jpg";
+
+    var self = this,
+      canvas,
+      newCanvas,
+      newCtx,
+      rawImg,
+      errored = false,
+      svgProcessedCount = 0,
+      svgTotalCount = 0,
+      svgAttrs = ["x", "y", "width", "height"],
+      svgDimension = [],
+      svgAttr;
+
+    var channelArray = [];
+
+    if (_self._showChannelNamesOverlay) {
+      for (id in this.channels) {
+        if (this.channels[id].isDisplay) {
+          channelArray.push([
+            this.channels[id].name,
+            this.channels[id].getOverlayColor(),
+          ]);
         }
-        else if(this.svgCollection.hasOwnProperty(data.svgID)){
-            // if(data.x1 && data.x2 && data.y1 && data.y2){
-            //     this.zoomInRectViewport(data)
-            // }
-            if(this.svgCollection.hasOwnProperty(this.current.svgID)){
-                this.svgCollection[this.current.svgID].changeSelectedGroup(this.current);
-            }
-            this.current.svgID = data.svgID;
-            this.current.groupID = data.groupID;
-
-            this.svgCollection[data.svgID].changeSelectedGroup(data);
-            this.svg.append(this.svgCollection[data.svgID].svg)
-        }
-
+      }
     }
 
-    // Change all SVGs annotations visibility
-    this.changeAllAnnotationVisibility = function(isDisplay){
-        for(var svgID in this.svgCollection){
-            this.svgCollection[svgID].changeAllVisibility(isDisplay);
-        }
+    // add watermark and download the file
+    var finalize = function () {
+      if (errored) return;
+
+      // add the water mark to the image
+      self._utils.addWaterMark2Canvas(
+        newCanvas,
+        self.parameters.waterMark,
+        self.osd.scalebarInstance,
+        channelArray
+      );
+
+      // turn it into an image
+      rawImg = newCanvas.toDataURL("image/jpeg", 1);
+      if (rawImg) {
+        self._utils.downloadAsFile(fileName, rawImg, "image/jpeg");
+        self.dispatchEvent("downloadViewDone");
+      } else {
+        // TODO proper error object
+        self.dispatchEvent("downloadViewError", new Error("Empty image"));
+      }
+    };
+
+    // get the displayed osd canvas
+    if (this.osd.scalebarInstance.pixelsPerMeter) {
+      canvas = this.osd.scalebarInstance.getImageWithScalebarAsCanvas();
+    } else {
+      canvas = self.osd.drawer.canvas;
     }
 
-    // Change scale stroke width
-    this.changeStrokeScale = function(strokeScale){
-        this.strokeScale = strokeScale;
-        for(var svgID in this.svgCollection){
-            this.svgCollection[svgID].changeStrokeScale();
-        }
+    // create a canvas the same size as the displayed osd canvas
+    newCanvas = document.createElement("canvas");
+    newCanvas.width = canvas.width;
+    newCanvas.height = canvas.height;
+    newCtx = newCanvas.getContext("2d");
+
+    // add the osd canvas content to the new canvas
+    newCtx.drawImage(
+      canvas,
+      0,
+      0,
+      canvas.width,
+      canvas.height,
+      0,
+      0,
+      canvas.width,
+      canvas.height
+    );
+
+    if (!_self.svg) {
+      finalize();
+      return;
     }
 
-    // Change SVG ID
-    this.changeSVGId = function(data){
+    // add the svg overlays to the new canvas by converting them to image
+    // TODO should be refactored
+    var svgs = _self.svg.querySelectorAll(".annotationSVG");
+    var pixelRatio = self._utils.queryForRetina(newCanvas);
+    svgs.forEach(function (svg) {
+      svgTotalCount++;
+      var img = new Image();
+      img.onload = function (e) {
+        if (errored) return;
 
-        // Change existing SVG id from the collection
-        if(this.svgCollection.hasOwnProperty(data.svgID)){
-            var prevSVG = this.svgCollection[data.svgID];
-            prevSVG.updateID(data.newSvgID);
-
-            this.svgCollection[data.newGroupID] = prevGroup;
-
-            // update the current svg id if it's also the changing svg id
-            if(this.current.svgID === data.svgID){
-                this.current.svgID = data.newSvgID;
-            };
-
-            delete this.svgCollection[data.svgID];
-
-            // continue to dispatch to parent to handle the necessary updates
-            this.dispatchEvent("updateGroupInfo", data);
-        }
-    }
-
-    // Handle events from children/ Dispatch events to toolbar
-    this.dispatchEvent = function (type, data) {
-
-        switch (type) {
-            /**
-             * [Handle events from children]
-             */
-            // Show group tooltip when mouse over
-            case "onMouseoverShowTooltip":
-                this.onMouseoverShowTooltip(data);
-                break;
-            // Adjust tooltip location when mouse move
-            case "onMousemoveShowTooltip":
-                this.onMousemoveShowTooltip(data);
-                break;
-            // Remove tooltip and border when mouse out of the svg
-            case "onMouseoutHideTooltip":
-                this.onMouseoutHideTooltip();
-                break;
-            // Create mousetracker to begin drawing
-            case "onDrawingBegin":
-                // alert("view start drawing")
-                var tracker = new OpenSeadragon.MouseTracker({
-                    element: _self.svg,
-                    dragHandler: this.onMouseDragToDraw,
-                    dragEndHandler: this.onMouseDragToDrawEnd,
-                    userData: data
-                });
-                _self.mouseTrackers.push(tracker);
-                break;
-            case "updateSVGId":
-                var prevSVG = this.svgCollection[data.svgID];
-                // update the current object -> change svg ID if matches the old one
-                if(this.current.svgID === data.svgID){
-                    this.current.svgID = data.newSvgID;
-                }
-                if(prevSVG){
-                    this.svgCollection[data.newSvgID] = prevSVG;
-                    delete this.svgCollection[data.svgID];
-                }
-
-                this.parent.dispatchEvent("updateSVGId", data);
-                break;
-            case "updateGroupInfo":
-                // update the current object -> change group ID if matches the old one
-                if(this.current.groupID === data.groupID){
-                    this.current.groupID = data.newGroupID;
-                }
-                this.parent.dispatchEvent("updateGroupInfo", data);
-                break;
-            /**
-             * [Dispatch events to App]
-             */
-            // Change current selected annotation group from toolbar
-            case "onClickChangeSelectingAnnotation":
-                if(_self.mode == modes.ERASE_ANNOTATIONS){
-                    this.dispatchSVGEvent("removeAnnotationByGraphID", {
-                        svgID : data.svgID,
-                        groupID : data.groupID,
-                        graphID : data.graphID
-                    })
-                }
-                else if(_self.mode == modes.VIEW){
-                    this.changeSelectingAnnotation(data);
-                    this.parent.dispatchEvent(type, {
-                        svgID : data.svgID,
-                        groupID : data.groupID
-                    });
-                }
-                break;
-            default:
-                this.parent.dispatchEvent(type, data);
-                break;
-        }
-    }
-
-    // Dispatch events to SVG objects
-    this.dispatchSVGEvent = function(type, data){
-
-        if(!this.svgCollection.hasOwnProperty(data.svgID)){
-            return
-        };
-
-        var svg = this.svgCollection[data.svgID];
-
-        switch(type){
-            // Add a new group
-            case "addNewGroup":
-                svg.createAnnotationGroup(data.groupID, data.anatomy, data.description);
-                break;
-            // Change an annotation group's visibility
-            case "changeAnnotationVisibility":
-                svg.changeVisibility(data);
-                break;
-            // Change stroke scale
-            case "changeStrokeScale":
-                svg.changeStrokeScale(data);
-                break;
-            // Change SVG ID
-            case "changeSVGId":
-                svg.changeSVGId(data);
-                break;
-            // Change group information:
-            case "changeGroupInfo":
-                svg.changeGroupInfo(data);
-                break;
-            // Drawing annotation on the SVG
-            case "drawingStart":
-                svg.createAnnotationObject(data.groupID, data.type, data.attrs);
-                break;
-            // Change the color of the annotation
-            case "drawingStrokeChanged":
-                svg.changeDrawingStroke(data);
-                break;
-            // Change current selected annotation group
-            case "highlightAnnotation":
-                this.changeSelectingAnnotation(data);
-                break;
-            // Change all annotation groups visibility
-            case "changeAllVisibility":
-                svg.changeAllVisibility(data.isDisplay);
-                break;
-            // Remove annotation object from a group
-            case "removeAnnotationByGraphID":
-                svg.removeAnnotationByGraphID(data.groupID, data.graphID);
-                this.dispatchEvent("onMouseoutHideTooltip");
-                break;
-            // Set annotation groups attributes
-            case "setGroupAttributes":
-                svg.setGroupAttributes(data);
-                break;
-            default:
-                break;
-        }
-    }
-
-    // Draw annotation mode on -> only show the related annotation objects
-    this.drawAnnotationMode = function(data){
-        // Check if the svg id exists
-        var svgID, groupID, isDisplay, foundAMatch = false, usedColors = [];
-        var mode = data.mode.toUpperCase();
-
-        var setStroke = (data.setStroke === true);
-        delete data.setStroke;
-
-        // remove all current mouse trackers
-        this.removeMouseTrackers();
-
-        // Hide all annotation objects
-        for(svgID in this.svgCollection){
-            if(mode == "ON"){
-                if(svgID == data.svgID){
-                    for(groupID in this.svgCollection[svgID].groups){
-                        // indicate whether we found a match or not
-                        foundAMatch = foundAMatch || groupID == data.groupID;
-
-                        // only show the matching group
-                        isDisplay = (groupID == data.groupID) ? true : false;
-                        this.svgCollection[svgID].groups[groupID].setDisplay(isDisplay);
-
-                        // set the drawing tool stroke to be based on the group stroke
-                        if (setStroke && groupID == data.groupID) {
-                            data.stroke = this.svgCollection[svgID].groups[groupID].stroke[0];
-                        }
-                    }
-                }
-                else{
-                    this.svgCollection[svgID].changeAllVisibility(false);
-                }
-            }
-            else{
-                this.svgCollection[svgID].changeAllVisibility(true);
-            }
-        };
-
-        // if we didn't find a matching group, use a random stroke
-        if (setStroke && !foundAMatch) {
-            // TODO could be improved by incorporating it with the other loop
-            // find the colors that are used, to avoid duplicate colors
-            for (svgID in this.svgCollection) {
-                for (groupID in this.svgCollection[svgID].groups) {
-                    usedColors = usedColors.concat(this.svgCollection[svgID].groups[groupID].stroke);
-                }
-            }
-            data.stroke = this._utils.generateColor(usedColors);
-        }
-
-        this.dispatchEvent("toggleDrawingTool", data);
-    }
-
-    /**
-     * Export the displayed view of osd viewer to a jpg file.
-     * Apart from the osd canvas, it will also add the svg overlays
-     * This function will trigger a browser download after processing is done.
-     * The messages that will be displatched by this function:
-     *  - `downloadViewDone`: when download is done.
-     *  - `downloadViewError`: if we encounter an error.
-     *
-     * @param {String=} fileName - the name of the file that will be downloaded
-     */
-    this.exportViewToJPG = function (fileName) {
-        fileName = fileName ? (fileName + ".jpg") : ("osd_" + Date.parse(new Date()) + ".jpg");
-
-        var self = this,
-            canvas, newCanvas, newCtx, rawImg, errored = false,
-            svgProcessedCount = 0, svgTotalCount = 0,
-            svgAttrs = ["x", "y", "width", "height"], svgDimension = [], svgAttr;
-
-        var channelArray = [];
-
-        if (_self._showChannelNamesOverlay) {
-            for (id in this.channels) {
-                if (this.channels[id].isDisplay) {
-                    channelArray.push([this.channels[id].name, this.channels[id].getOverlayColor()])
-                }
-            }
-        }
-
-        // add watermark and download the file
-        var finalize = function () {
-            if (errored) return;
-
-            // add the water mark to the image
-            self._utils.addWaterMark2Canvas(newCanvas, self.parameters.waterMark, self.osd.scalebarInstance, channelArray);
-
-            // turn it into an image
-            rawImg = newCanvas.toDataURL("image/jpeg", 1);
-            if (rawImg) {
-                self._utils.downloadAsFile(fileName, rawImg, "image/jpeg");
-                self.dispatchEvent('downloadViewDone');
-            } else {
-                // TODO proper error object
-                self.dispatchEvent('downloadViewError', new Error("Empty image"));
-            }
-        }
-
-        // get the displayed osd canvas
-        if (this.osd.scalebarInstance.pixelsPerMeter) {
-            canvas = this.osd.scalebarInstance.getImageWithScalebarAsCanvas();
-        } else {
-            canvas = self.osd.drawer.canvas;
-        }
-
-        // create a canvas the same size as the displayed osd canvas
-        newCanvas = document.createElement("canvas");
-        newCanvas.width = canvas.width;
-        newCanvas.height = canvas.height;
-        newCtx = newCanvas.getContext("2d");
-
-        // add the osd canvas content to the new canvas
-        newCtx.drawImage(canvas, 0, 0, canvas.width, canvas.height, 0, 0, canvas.width, canvas.height);
-
-        if (!_self.svg) {
-            finalize();
-            return;
-        }
-
-        // add the svg overlays to the new canvas by converting them to image
-        // TODO should be refactored
-        var svgs = _self.svg.querySelectorAll(".annotationSVG");
-        var pixelRatio = self._utils.queryForRetina(newCanvas);
-        svgs.forEach(function (svg) {
-            svgTotalCount++;
-            var img = new Image();
-            img.onload = function(e) {
-                if (errored) return;
-
-                svgAttrs.forEach(function (attrName) {
-                    svgAttr = svg.getAttribute(attrName);
-                    if (svgAttr == null) {
-                        svgAttr = 0;
-                    }
-                    if (typeof svgAttr === "string") {
-                        svgAttr = svgAttr.replace("px", "");
-                    }
-                    // osd is property handling pixel ratio, so we don't need to change the canvas settings.
-                    // instead while drawing the annotation manually on top of the canvas, we should take care of pixelRatio
-                    svgDimension.push(Number(svgAttr) * pixelRatio);
-                });
-
-                // add the image to new canvas
-                newCtx.drawImage(e.target, svgDimension[0], svgDimension[1], svgDimension[2], svgDimension[3]);
-
-                svgProcessedCount++
-                if (svgProcessedCount === svgTotalCount) {
-                    finalize();
-                }
-            };
-            img.onerror = function (message, source, lineno, colno, error) {
-                console.log(error);
-
-                // only one error message is enough.
-                if (errored) return;
-                errored = true;
-
-                // TODO proper error object
-                self.dispatchEvent('downloadViewError', error);
-            }
-            // NOTE source has to be defined after onload and onerror
-            img.src = null;
-            img.src = "data:image/svg+xml;utf8," + encodeURIComponent(new XMLSerializer().serializeToString(svg));
+        svgAttrs.forEach(function (attrName) {
+          svgAttr = svg.getAttribute(attrName);
+          if (svgAttr == null) {
+            svgAttr = 0;
+          }
+          if (typeof svgAttr === "string") {
+            svgAttr = svgAttr.replace("px", "");
+          }
+          // osd is property handling pixel ratio, so we don't need to change the canvas settings.
+          // instead while drawing the annotation manually on top of the canvas, we should take care of pixelRatio
+          svgDimension.push(Number(svgAttr) * pixelRatio);
         });
 
-        // in case there wasn't any svg overlays
+        // add the image to new canvas
+        newCtx.drawImage(
+          e.target,
+          svgDimension[0],
+          svgDimension[1],
+          svgDimension[2],
+          svgDimension[3]
+        );
+
+        svgProcessedCount++;
         if (svgProcessedCount === svgTotalCount) {
-            finalize();
+          finalize();
         }
-    }
+      };
+      img.onerror = function (message, source, lineno, colno, error) {
+        console.log(error);
 
-    // Get channels
-    this.getChannels = function () {
-        return this.channels;
-    }
+        // only one error message is enough.
+        if (errored) return;
+        errored = true;
 
-    this.getStrokeScale = function(){
-        return this.strokeScale;
-    }
+        // TODO proper error object
+        self.dispatchEvent("downloadViewError", error);
+      };
+      // NOTE source has to be defined after onload and onerror
+      img.src = null;
+      img.src =
+        "data:image/svg+xml;utf8," +
+        encodeURIComponent(new XMLSerializer().serializeToString(svg));
+    });
 
-    // Load and import the unstructured SVG file into Openseadragon viewer
-    this.importAnnotationUnformattedSVG = function (svgs) {
-        /*
+    // in case there wasn't any svg overlays
+    if (svgProcessedCount === svgTotalCount) {
+      finalize();
+    }
+  };
+
+  // Get channels
+  this.getChannels = function () {
+    return this.channels;
+  };
+
+  this.getStrokeScale = function () {
+    return this.strokeScale;
+  };
+
+  // Load and import the unstructured SVG file into Openseadragon viewer
+  this.importAnnotationUnformattedSVG = function (svgs) {
+    /*
           We show all the svg files in relative to the position of the first scene,
           even if the svgs might belong to other scenes.
           to make the calculations simpler, we're always positioning the svgs
           relative to the location of first scene (and not the scene that they belong to).
         */
-        var ignoreReferencePoint = this.parameters.ignoreReferencePoint,
-            ignoreDimension = this.parameters.ignoreDimension,
-            imgWidth = this.osd.world.getItemAt(0).getContentSize().x,
-            imgHeight = this.osd.world.getItemAt(0).getContentSize().y;
+    var ignoreReferencePoint = this.parameters.ignoreReferencePoint,
+      ignoreDimension = this.parameters.ignoreDimension,
+      imgWidth = this.osd.world.getItemAt(0).getContentSize().x,
+      imgHeight = this.osd.world.getItemAt(0).getContentSize().y;
 
-        for(var i = 0; i < svgs.length; i++){
-            var id = Date.parse(new Date()) + parseInt(Math.random() * 10000),
-                svgFileLocation = svgs[i],
-                content = this._utils.getUrlContent(svgFileLocation),
-                svgParser = new DOMParser(),
-                svgFile = svgParser.parseFromString(content, "image/svg+xml"),
-                svgFile = svgFile.getElementsByTagName("svg")[0];
+    for (var i = 0; i < svgs.length; i++) {
+      var id = Date.parse(new Date()) + parseInt(Math.random() * 10000),
+        svgFileLocation = svgs[i],
+        content = this._utils.getUrlContent(svgFileLocation),
+        svgParser = new DOMParser(),
+        svgFile = svgParser.parseFromString(content, "image/svg+xml"),
+        svgFile = svgFile.getElementsByTagName("svg")[0];
 
-            this.svgCollection[id] = new AnnotationSVG(this, id, imgWidth, imgHeight, this.scale, ignoreReferencePoint, ignoreDimension);
-            this.svgCollection[id].parseSVGFile(svgFile);
+      this.svgCollection[id] = new AnnotationSVG(
+        this,
+        id,
+        imgWidth,
+        imgHeight,
+        this.scale,
+        ignoreReferencePoint,
+        ignoreDimension
+      );
+      this.svgCollection[id].parseSVGFile(svgFile);
 
-            if(!content) {
-              this.dispatchEvent('errorAnnotation');
-            }
-        }
-
+      if (!content) {
+        this.dispatchEvent("errorAnnotation");
+      }
     }
+  };
 
-    // Load after Openseadragon initialized
-    this.loadAfterOSDInit = function(){
-        // Only execute it once when Openseadragon is done loading
-        if (!_self.isInitLoad) {
+  // Load after Openseadragon initialized
+  this.loadAfterOSDInit = function () {
+    // Only execute it once when Openseadragon is done loading
+    if (!_self.isInitLoad) {
+      // Check if need to pan to a specific location (if x, y, z are not null)
+      if (_self.parameters.x && _self.parameters.y && _self.parameters.z) {
+        _self.panTo(
+          _self.parameters.x,
+          _self.parameters.y,
+          _self.parameters.x,
+          _self.parameters.z
+        );
+      }
 
-            // Check if need to pan to a specific location (if x, y, z are not null)
-            if (_self.parameters.x && _self.parameters.y && _self.parameters.z) {
-                _self.panTo(_self.parameters.x, _self.parameters.y, _self.parameters.x, _self.parameters.z);
-            }
+      // Check if `scale` is provided
+      if (_self.parameters.scale) {
+        _self.scale = _self.parameters.scale;
+      }
 
-            // Check if `scale` is provided
-            if(_self.parameters.scale) {
-                _self.scale = _self.parameters.scale;
-            }
+      // Check if `meterScaleInPixels` if provided
+      if (_self.parameters.meterScaleInPixels) {
+        var meterScaleInPixels = _self.parameters.meterScaleInPixels;
+        _self.resetScalebar(meterScaleInPixels);
+        _self.osd.scalebar({ stayInsideImage: _self.stayInsideImage });
+      }
 
-            // Check if `meterScaleInPixels` if provided
-            if(_self.parameters.meterScaleInPixels){
-                var meterScaleInPixels = _self.parameters.meterScaleInPixels;
-                _self.resetScalebar(meterScaleInPixels);
-                _self.osd.scalebar({stayInsideImage: _self.stayInsideImage});
-            }
-
-            // Check if annotation exists in the url
-            if(_self.parameters.annotationSetURLs) {
-                try {
-                    _self.importAnnotationUnformattedSVG(_self.parameters.annotationSetURLs);
-                    _self.dispatchEvent('annotationsLoaded');
-                } catch (err) {
-                    _self.dispatchEvent('errorAnnotation', err);
-                }
-                _self.resizeSVG();
-            }
-
-            _self.isInitLoad = true;
-
-        }
-
-        _self.dispatchEvent('mainImageLoaded');
-    }
-
-    /**
-     * Load the given list of svg urls and display them as annotations.
-     * NOTE: It will remove the existing annotations and only show the new given inputs
-     * It will directly dispatch the following messages:
-     *   - annotationsLoaded: when all the annotations are processed.
-     *   - errorAnnotation: when encountered an error while loading annotations
-     * @param {String[]} svgURLs - svg urls
-     */
-    this.loadSVGAnnotations = function (svgURLs) {
-        if (!Array.isArray(svgURLs) || svgURLs.length === 0) {
-            _self.dispatchEvent('annotationsLoaded');
-            return;
-        }
+      // Check if annotation exists in the url
+      if (_self.parameters.annotationSetURLs) {
         try {
-            // add the svgs
-            _self.importAnnotationUnformattedSVG(svgURLs);
-
-            // let caller know that it is done
-            _self.dispatchEvent('annotationsLoaded');
+          _self.importAnnotationUnformattedSVG(
+            _self.parameters.annotationSetURLs
+          );
+          _self.dispatchEvent("annotationsLoaded");
         } catch (err) {
-            _self.dispatchEvent('errorAnnotation', err);
+          _self.dispatchEvent("errorAnnotation", err);
         }
         _self.resizeSVG();
+      }
+
+      _self.isInitLoad = true;
     }
 
-    /**
-     * {channelNumber, channelName, pseudoColor, meterScaleInPixels, channelConfig}
-     */
-    this.getChannelInfo = function (channelNumber) {
-        if (!Array.isArray(_self.parameters.channels)) {
-            return {};
+    _self.dispatchEvent("mainImageLoaded");
+  };
+
+  /**
+   * Load the given list of svg urls and display them as annotations.
+   * NOTE: It will remove the existing annotations and only show the new given inputs
+   * It will directly dispatch the following messages:
+   *   - annotationsLoaded: when all the annotations are processed.
+   *   - errorAnnotation: when encountered an error while loading annotations
+   * @param {String[]} svgURLs - svg urls
+   */
+  this.loadSVGAnnotations = function (svgURLs) {
+    if (!Array.isArray(svgURLs) || svgURLs.length === 0) {
+      _self.dispatchEvent("annotationsLoaded");
+      return;
+    }
+    try {
+      // add the svgs
+      _self.importAnnotationUnformattedSVG(svgURLs);
+
+      // let caller know that it is done
+      _self.dispatchEvent("annotationsLoaded");
+    } catch (err) {
+      _self.dispatchEvent("errorAnnotation", err);
+    }
+    _self.resizeSVG();
+  };
+
+  /**
+   * {channelNumber, channelName, pseudoColor, meterScaleInPixels, channelConfig}
+   */
+  this.getChannelInfo = function (channelNumber) {
+    if (!Array.isArray(_self.parameters.channels)) {
+      return {};
+    }
+
+    var item = _self.parameters.channels.filter(function (el) {
+      return el.channelNumber == channelNumber;
+    });
+
+    if (item.length === 1) {
+      return item[0];
+    }
+    return {};
+  };
+
+  // Load Image and Channel information
+  // params: {zIndex, info: {url, channelNumber}}
+  this.loadImages = function (params) {
+    if (typeof params != "object" && !Array.isArray(params.info)) {
+      return;
+    }
+
+    console.log("params: ", params);
+    var channelList = [],
+      i,
+      usePreviousChannelInfo = false;
+
+    // show spinner is displayed
+    _self.resetSpinner(true);
+
+    // remove the existing images
+    if (_self.osd.world.getItemCount() > 0) {
+      // if the number of channels between Zs didnt change
+      // (this should always be true, it's just an additional check)
+      usePreviousChannelInfo =
+        _self.osd.world.getItemCount() === Object.keys(_self.channels).length;
+
+      // remove existing images
+      _self.osd.world.removeAll();
+    }
+
+    // process the images
+    for (i = 0; i < params.info.length; i++) {
+      var channel,
+        tileSource,
+        info = params.info[i],
+        options = {},
+        meterScaleInPixels = null;
+
+      var url = info.url;
+
+      var channelInfo = _self.getChannelInfo(info.channelNumber);
+
+      // The below code is for aliasName used in place of channelName
+      var channelName = channelInfo.channelName ? channelInfo.channelName : "";
+      if (channelInfo.aliasName) {
+        channelName = channelInfo.aliasName;
+      }
+      // use the index for the channelName
+      if (typeof channelName !== "string" || channelName.length === 0) {
+        channelName = i.toString();
+      }
+
+      // create tileSource and options based on the image type
+      if (url.indexOf("ImageProperties.xml") !== -1) {
+        var xmlString = _self._utils.getUrlContent(url),
+          imgPath = url.replace("/ImageProperties.xml", ""),
+          xmlParser = new DOMParser();
+
+        var xmlDoc = xmlParser.parseFromString(
+          xmlString.trim(),
+          "application/xml"
+        );
+        xmlDoc = xmlDoc.getElementsByTagName("IMAGE_PROPERTIES")[0];
+
+        // we want to properly define how to get the images from the
+        // folder structure that we have for dzi images
+        tileSource = options = _self.buildTileSource(xmlDoc, imgPath);
+        if (options.channelName) {
+          channelName = options.channelName;
+        }
+      } else if (url.indexOf("info.json") !== -1) {
+        // since osd supports iiif images, we can just pass the url
+        tileSource = url;
+      } else {
+        // we have to specify the type, just passing url to osd doesn't work
+        tileSource = {
+          type: "image",
+          url: url,
+        };
+      }
+
+      // make sure the scale is properly defined
+      meterScaleInPixels = options.meterScaleInPixels
+        ? options.meterScaleInPixels
+        : meterScaleInPixels;
+      meterScaleInPixels = _self.parameters.meterScaleInPixels
+        ? _self.parameters.meterScaleInPixels
+        : meterScaleInPixels;
+      _self.scale =
+        meterScaleInPixels != null ? 1000000 / meterScaleInPixels : null;
+
+      _self.resetScalebar(meterScaleInPixels);
+
+      if (usePreviousChannelInfo) {
+        channel = _self.channels[i];
+      } else {
+        // pseudoColor
+        if (typeof channelInfo.pseudoColor === "string") {
+          // it might be hex
+          var hexToRGB = _self._utils.colorHexToRGB(channelInfo.pseudoColor);
+          options.pseudoColor = hexToRGB ? hexToRGB : channelInfo.pseudoColor;
         }
 
-        var item = _self.parameters.channels.filter(function (el) {
-            return el.channelNumber == channelNumber;
+        // isRGB
+        if (typeof channelInfo.isRGB === "boolean") {
+          options.isRGB = channelInfo.isRGB;
+        }
+
+        // config
+        if (
+          typeof channelInfo.channelConfig === "object" &&
+          channelInfo.channelConfig != null
+        ) {
+          options.channelConfig = channelInfo.channelConfig;
+        }
+
+        // channel acls
+        if (typeof channelInfo.acls === "object" && channelInfo.acls != null) {
+          options.acls = channelInfo.acls;
+        }
+
+        // used for internal logic of channel
+        options["isMultiChannel"] = params.info.length > 1;
+
+        // by default we're only channel name overlay for multi-channel images
+        _self._showChannelNamesOverlay = params.info.length > 1;
+
+        // only show a few first
+        options["isDisplay"] =
+          i < _self.config.constants.MAX_NUM_DEFAULT_CHANNEL;
+
+        // add to the list of channels
+        channel = new Channel(i, channelName, info.channelNumber, options);
+
+        _self.channels[i] = channel;
+        channelList.push({
+          number: info.channelNumber,
+          name: channel.name,
+          blackLevel: channel["blackLevel"],
+          whiteLevel: channel["whiteLevel"],
+          gamma: channel["gamma"],
+          saturation: channel["saturation"],
+          hue: channel["hue"],
+          displayGreyscale: channel["displayGreyscale"],
+          osdItemId: channel["id"],
+          isDisplay: channel["isDisplay"],
+          acls: options["acls"],
         });
+      }
 
-        if (item.length === 1) {
-            return item[0];
-        }
-        return {};
+      // add the image
+      _self.osd.addTiledImage({
+        tileSource: tileSource,
+        compositeOperation: "lighter",
+        opacity: channel["isDisplay"] ? 1 : 0,
+      });
     }
 
-    // Load Image and Channel information
-    // params: {zIndex, info: {url, channelNumber}}
-    this.loadImages = function (params) {
-        if (typeof params != 'object' && !Array.isArray(params.info)) {
-            return;
-        }
+    if (!usePreviousChannelInfo) {
+      // Dispatch event to toolbar to update channel list
+      _self.dispatchEvent("replaceChannelList", {
+        channelList: channelList,
+        showChannelNamesOverlay: _self._showChannelNamesOverlay,
+      });
+    }
+  };
 
-        console.log('params: ', params);
-        var channelList = [], i, usePreviousChannelInfo = false;
-
-        // show spinner is displayed
-        _self.resetSpinner(true);
-
-        // remove the existing images
-        if (_self.osd.world.getItemCount() > 0) {
-
-            // if the number of channels between Zs didnt change
-            // (this should always be true, it's just an additional check)
-            usePreviousChannelInfo = (_self.osd.world.getItemCount() === Object.keys(_self.channels).length);
-
-            // remove existing images
-            _self.osd.world.removeAll();
-        }
-
-        // process the images
-        for (i = 0; i < params.info.length; i++) {
-            var channel,
-                tileSource,
-                info = params.info[i],
-                options = {},
-                meterScaleInPixels = null;
-
-            var url = info.url;
-
-            var channelInfo = _self.getChannelInfo(info.channelNumber);
-
-            // The below code is for aliasName used in place of channelName
-            var channelName = channelInfo.channelName ? channelInfo.channelName : "";
-            if (channelInfo.aliasName) {
-                channelName = channelInfo.aliasName;
-            }
-            // use the index for the channelName
-            if (typeof channelName !== "string" || channelName.length === 0) {
-                channelName = i.toString();
-            }
-
-            // create tileSource and options based on the image type
-            if (url.indexOf('ImageProperties.xml') !== -1) {
-                var xmlString = _self._utils.getUrlContent(url),
-                    imgPath = url.replace('/ImageProperties.xml', ''),
-                    xmlParser = new DOMParser();
-
-                var xmlDoc = xmlParser.parseFromString(xmlString.trim(), "application/xml");
-                xmlDoc = xmlDoc.getElementsByTagName("IMAGE_PROPERTIES")[0];
-
-                // we want to properly define how to get the images from the
-                // folder structure that we have for dzi images
-                tileSource = options = _self.buildTileSource(xmlDoc, imgPath);
-                if (options.channelName) {
-                    channelName = options.channelName;
-                }
-            } else if (url.indexOf("info.json") !== -1){
-                // since osd supports iiif images, we can just pass the url
-                tileSource = url;
-            } else {
-                // we have to specify the type, just passing url to osd doesn't work
-                tileSource = {
-                    type: 'image',
-                    url: url
-                };
-            }
-
-            // make sure the scale is properly defined
-            meterScaleInPixels = options.meterScaleInPixels ? options.meterScaleInPixels : meterScaleInPixels;
-            meterScaleInPixels = _self.parameters.meterScaleInPixels ? _self.parameters.meterScaleInPixels : meterScaleInPixels;
-            _self.scale = (meterScaleInPixels != null) ? 1000000 / meterScaleInPixels : null;
-
-            _self.resetScalebar(meterScaleInPixels);
-
-            if (usePreviousChannelInfo) {
-                channel = _self.channels[i];
-            } else {
-                // pseudoColor
-                if (typeof channelInfo.pseudoColor === 'string') {
-                    // it might be hex
-                    var hexToRGB = _self._utils.colorHexToRGB(channelInfo.pseudoColor);
-                    options.pseudoColor = hexToRGB ? hexToRGB : channelInfo.pseudoColor;
-                }
-
-                // isRGB
-                if (typeof channelInfo.isRGB === 'boolean') {
-                    options.isRGB = channelInfo.isRGB;
-                }
-
-                // config
-                if (typeof channelInfo.channelConfig === "object" && channelInfo.channelConfig != null) {
-                    options.channelConfig = channelInfo.channelConfig;
-                }
-
-                // channel acls
-                if (typeof channelInfo.acls === "object" && channelInfo.acls != null) {
-                    options.acls = channelInfo.acls;
-                }
-
-                // used for internal logic of channel
-                options['isMultiChannel'] = (params.info.length > 1);
-
-                // by default we're only channel name overlay for multi-channel images
-                _self._showChannelNamesOverlay = (params.info.length > 1);
-
-                // only show a few first
-                options["isDisplay"] = (i < _self.config.constants.MAX_NUM_DEFAULT_CHANNEL);
-
-                // add to the list of channels
-                channel = new Channel(i, channelName, info.channelNumber, options);
-
-                _self.channels[i] = channel;
-                channelList.push({
-                    number: info.channelNumber,
-                    name: channel.name,
-                    blackLevel: channel["blackLevel"],
-                    whiteLevel: channel["whiteLevel"],
-                    gamma: channel["gamma"],
-                    saturation: channel["saturation"],
-                    hue : channel["hue"],
-                    displayGreyscale : channel['displayGreyscale'],
-                    osdItemId: channel["id"],
-                    isDisplay: channel["isDisplay"],
-                    acls: options['acls']
-                });
-            }
-
-
-            // add the image
-            _self.osd.addTiledImage({
-                tileSource: tileSource,
-                compositeOperation: 'lighter',
-                opacity: (channel["isDisplay"] ? 1 : 0)
-            });
-        }
-
-        if (!usePreviousChannelInfo) {
-            // Dispatch event to toolbar to update channel list
-            _self.dispatchEvent('replaceChannelList', {
-                channelList: channelList,
-                showChannelNamesOverlay: _self._showChannelNamesOverlay
-            });
-        }
-
+  // Show tooltip when mouse over the annotation on Openseadragon viewer
+  this.onMouseoverShowTooltip = function (data) {
+    if (document.querySelector("#annotationTooltip") == null) {
+      var tooltipElem = [
+        "<div id='annotationTooltip'>",
+        "<span class='row' data-type='anatomy'>",
+        "<span class='name'> Anatomy : </span>",
+        "<span class='desc'>" + data.anatomy + "</span>",
+        "</span>",
+        "</div>",
+      ].join("");
+      document
+        .querySelector("#" + this.config.osd.id)
+        .insertAdjacentHTML("beforeend", tooltipElem);
+      this.tooltipElem = d3.select("div#annotationTooltip");
     }
 
-    // Show tooltip when mouse over the annotation on Openseadragon viewer
-    this.onMouseoverShowTooltip = function(data){
+    this.tooltipElem
+      .style("display", "flex")
+      .transition()
+      .duration(300)
+      .style("opacity", 0.9)
+      .style("left", data.x + 20 + "px")
+      .style("top", data.y + 20 + "px");
+  };
 
-        if(document.querySelector("#annotationTooltip") == null){
-            var tooltipElem = [
-                "<div id='annotationTooltip'>",
-                    "<span class='row' data-type='anatomy'>",
-                        "<span class='name'> Anatomy : </span>",
-                        "<span class='desc'>"+data.anatomy+"</span>",
-                    "</span>",
-                "</div>"
-            ].join("");
-            document.querySelector("#" + this.config.osd.id).insertAdjacentHTML('beforeend', tooltipElem);
-            this.tooltipElem = d3.select("div#annotationTooltip");
-        }
-
-        this.tooltipElem
-            .style("display", "flex")
-            .transition()
-            .duration(300)
-            .style("opacity", 0.9)
-            .style("left", (data.x + 20) + "px")
-            .style("top", (data.y + 20) + "px");
+  // Move annotation tooltip when mouse move on Openseadragon viewer
+  this.onMousemoveShowTooltip = function (data) {
+    if (!this.tooltipElem || !data) {
+      return;
     }
 
-    // Move annotation tooltip when mouse move on Openseadragon viewer
-    this.onMousemoveShowTooltip = function(data){
-        if(!this.tooltipElem || !data){
-            return;
-        }
+    this.tooltipElem
+      .style("left", data.x + 20 + "px")
+      .style("top", data.y + 20 + "px");
+  };
 
-        this.tooltipElem
-            .style("left", (data.x + 20) + "px")
-            .style("top", (data.y + 20) + "px");
+  // Hide annotation tooltip when mouse out of the annotation on Openseadragon viewer
+  this.onMouseoutHideTooltip = function () {
+    if (!this.tooltipElem) {
+      return;
     }
 
-    // Hide annotation tooltip when mouse out of the annotation on Openseadragon viewer
-    this.onMouseoutHideTooltip = function(){
-        if(!this.tooltipElem){
-            return;
-        }
+    this.tooltipElem
+      // .transition()
+      // .duration(300)
+      .style("opacity", 0)
+      .remove();
+  };
 
-        this.tooltipElem
-            // .transition()
-            // .duration(300)
-            .style("opacity", 0)
-            .remove();
+  // Drag to draw event handler start
+  this.onMouseDragToDraw = function (event) {
+    var annotation = event.userData.annotation;
+    var viewBox = event.userData.viewBox;
+    var scaleX = event.userData.imgScaleX || 1;
+    var scaleY = event.userData.imgScaleY || 1;
+    var view_coords = _self.osd.viewport.viewerElementToViewportCoordinates(
+      new OpenSeadragon.Point(event.position.x, event.position.y)
+    );
+    var img_coords = _self.osd.viewport.viewportToImageCoordinates(view_coords);
+
+    img_coords.x = viewBox[0] + img_coords.x * scaleX;
+    img_coords.y = viewBox[1] + img_coords.y * scaleY;
+
+    // console.log(event.position, img_coords);
+    annotation.insertPoint(img_coords);
+  };
+
+  // Drag to draw event handler end
+  this.onMouseDragToDrawEnd = function (event) {
+    if (event.userData.type == "POLYGON") {
+      event.userData.annotation.insertPointAtDrawEnd();
+      return;
     }
 
-    // Drag to draw event handler start
-    this.onMouseDragToDraw = function(event){
-        var annotation = event.userData.annotation;
-        var viewBox = event.userData.viewBox;
-        var scaleX = event.userData.imgScaleX || 1;
-        var scaleY = event.userData.imgScaleY || 1;
-        var view_coords = _self.osd.viewport.viewerElementToViewportCoordinates(new OpenSeadragon.Point(event.position.x, event.position.y));
-        var img_coords = _self.osd.viewport.viewportToImageCoordinates(view_coords);
-
-        img_coords.x = viewBox[0] + (img_coords.x * scaleX);
-        img_coords.y = viewBox[1] + (img_coords.y * scaleY);
-
-        // console.log(event.position, img_coords);
-        annotation.insertPoint(img_coords);
-
+    if (_self.mouseTrackers.length > 0) {
+      setTimeout(function () {
+        _self.mouseTrackers[0].destroy();
+        _self.mouseTrackers.shift();
+      }, 300);
     }
 
-    // Drag to draw event handler end
-    this.onMouseDragToDrawEnd = function(event){
+    event.userData.annotation.setDrawing(false);
 
-        if (event.userData.type == "POLYGON") {
-            event.userData.annotation.insertPointAtDrawEnd();
-            return;
-        }
+    var svgID = event.userData.svgID;
+    var groupID = event.userData.groupID;
+    var type = event.userData.type;
+    var attrs = event.userData.attrs || {};
 
-        if (_self.mouseTrackers.length > 0) {
-            setTimeout(function () {
-                _self.mouseTrackers[0].destroy();
-                _self.mouseTrackers.shift();
-            }, 300)
-        }
+    if (
+      _self.svgCollection[svgID] &&
+      _self.svgCollection[svgID].groups[groupID]
+    ) {
+      event.userData.annotation =
+        _self.svgCollection[svgID].groups[groupID].addAnnotation(type);
+      event.userData.annotation.setupDrawingAttrs(attrs);
+      event.userData.graphID = event.userData.annotation.id;
 
-        event.userData.annotation.setDrawing(false);
+      var mousetracker = new OpenSeadragon.MouseTracker({
+        element: _self.svg,
+        dragHandler: _self.onMouseDragToDraw,
+        dragEndHandler: _self.onMouseDragToDrawEnd,
+        userData: event.userData,
+      });
 
-        var svgID = event.userData.svgID;
-        var groupID = event.userData.groupID;
-        var type = event.userData.type;
-        var attrs = event.userData.attrs || {};
+      _self.mouseTrackers.push(mousetracker);
+    }
+    // _self.destoryMouseTracker();
+  };
 
-        if (_self.svgCollection[svgID] && _self.svgCollection[svgID].groups[groupID]) {
-            event.userData.annotation = _self.svgCollection[svgID].groups[groupID].addAnnotation(type);
-            event.userData.annotation.setupDrawingAttrs(attrs);
-            event.userData.graphID = event.userData.annotation.id;
+  // Pan to specific location
+  this.panTo = function (x, y, z) {
+    var centerPoint = new OpenSeadragon.Point(x, y);
+    _self.osd.viewport.panTo(centerPoint, "true");
 
-            var mousetracker = new OpenSeadragon.MouseTracker({
-                element: _self.svg,
-                dragHandler: _self.onMouseDragToDraw,
-                dragEndHandler: _self.onMouseDragToDrawEnd,
-                userData: event.userData
-            });
-
-            _self.mouseTrackers.push(mousetracker);
-        }
-        // _self.destoryMouseTracker();
+    if (z != null) {
+      _self.osd.viewport.zoomTo(_self.parameters.z);
     }
 
-    // Pan to specific location
-    this.panTo = function (x, y, z) {
-        var centerPoint = new OpenSeadragon.Point(x, y);
-        _self.osd.viewport.panTo(centerPoint, 'true');
+    _self.osd.viewport.applyConstraints();
+  };
 
-        if (z != null) {
-            _self.osd.viewport.zoomTo(_self.parameters.z);
+  // Render annotation tooltip when user's mouse hover the annotation
+  this.renderAnnotationTooltip = function () {
+    var tooltipElem = "";
+    var container = document.getElementById("container");
+
+    if (this.tooltipElem == null) {
+      tooltipElem = [
+        "<div id='annotationTooltip'>",
+        "<span class='row anatomy' data-type='anatomy'></span>",
+        "<span class='row description' data-type='description'></span>",
+        "</div>",
+      ].join("");
+
+      container.insertAdjacentHTML("beforeend", tooltipElem);
+
+      this.tooltipElem = d3.select("#annotationTooltip");
+    }
+  };
+
+  this.removeAllSVGAnnotations = function () {
+    // remove the existing svgs
+    var svgIDs = Object.keys(_self.svgCollection);
+    svgIDs.forEach(function (id) {
+      _self.removeSVG(id);
+    });
+  };
+
+  // Remove specific svg object by svgID
+  this.removeSVG = function (svgID) {
+    var svgObj = this.svgCollection[svgID];
+
+    if (svgObj) {
+      // remove all the groups, which contain annotations
+      svgObj.removeAllGroups();
+
+      // remove svg element
+      svgObj.svg.remove();
+
+      delete this.svgCollection[svgID];
+    }
+  };
+
+  // Remove overlay
+  this.removeOverlay = function (element) {
+    this.osd.removeOverlay(element);
+  };
+
+  // Remove mouse trackers for drawing
+  this.removeMouseTrackers = function (data) {
+    if (this.mouseTrackers.length > 0) {
+      while (this.mouseTrackers.length > 0) {
+        var tracker = this.mouseTrackers.shift();
+        var userData = tracker.userData;
+
+        if (userData && userData.type != "POLYGON") {
+          this.dispatchSVGEvent("removeAnnotationByGraphID", {
+            svgID: userData.svgID,
+            groupID: userData.groupID,
+            graphID: userData.graphID,
+          });
         }
 
-        _self.osd.viewport.applyConstraints();
+        setTimeout(function () {
+          tracker.destroy();
+        }, 300);
+      }
     }
+  };
 
-    // Render annotation tooltip when user's mouse hover the annotation
-    this.renderAnnotationTooltip = function () {
-        var tooltipElem = "";
-        var container = document.getElementById("container");
-
-        if (this.tooltipElem == null) {
-
-            tooltipElem = [
-                "<div id='annotationTooltip'>",
-                "<span class='row anatomy' data-type='anatomy'></span>",
-                "<span class='row description' data-type='description'></span>",
-                "</div>"
-            ].join("");
-
-            container.insertAdjacentHTML('beforeend', tooltipElem);
-
-            this.tooltipElem = d3.select("#annotationTooltip");
-        }
+  this.resetSpinner = function (show) {
+    if (this.config.osd.spinnerID) {
+      var sp = document.querySelector("#" + this.config.osd.spinnerID);
+      if (sp) {
+        sp.style.display = show ? "block" : "none";
+      }
     }
+  };
 
-    this.removeAllSVGAnnotations = function () {
-        // remove the existing svgs
-        var svgIDs = Object.keys(_self.svgCollection);
-        svgIDs.forEach(function (id) {
-            _self.removeSVG(id);
+  // Reset the scalebar measurement (pixel per meter) with new value
+  this.resetScalebar = function (value) {
+    this.osd.scalebar({
+      location: OpenSeadragon.ScalebarLocation.BOTTOM_RIGHT,
+      pixelsPerMeter: value,
+    });
+  };
+
+  // Reset Openseadragon to home view
+  this.resetHomeView = function () {
+    this.osd.viewport.goHome();
+    this.osd.viewport.applyConstraints();
+  };
+
+  /**
+   * This function reads the URL param zoomLineThickness, and decides which stroke-width scale function to select
+   * log = the thickness vaires according to the log of the current zoom level. Since at each zoom in/out the zoom level changes by a factor of 2, i.e. it changes exponentially, therefore using a log approach provides linear change in line-thickness with respect to each zoom in/out click.
+   * default = using the original function, i.e. mapping the line thickness linearly with the total zoom levels avaibale in the OSD
+   * @return {function} the function is responsible for how the line-thickness vaires with respect of current zoom level
+   */
+  this.getStrokeWidthScaleFunction = function () {
+    switch (this.parameters.zoomLineThickness) {
+      case "log":
+        return function (value) {
+          var minZoom = _self.osd.viewport.getMinZoom();
+          var maxZoom = _self.osd.viewport.getMaxZoom();
+          var zoomLevels = Math.ceil(Math.log2(maxZoom) - Math.log2(minZoom));
+          var currentZoomLevel = Math.ceil(
+            Math.log2(value) - Math.log2(minZoom)
+          );
+
+          var delta = _self.strokeMaxScale - _self.strokeMinScale;
+          var result = (delta * currentZoomLevel) / zoomLevels;
+
+          return Math.max(_self.strokeMinScale, _self.strokeMaxScale - result);
+        };
+      default:
+        return d3
+          .scaleLinear()
+          .domain([
+            _self.osd.viewport.getMinZoom(),
+            _self.osd.viewport.getMaxZoom(),
+          ])
+          .range([_self.strokeMaxScale, _self.strokeMinScale])
+          .nice();
+    }
+  };
+
+  // Resize Annotation SVGs
+  this.resizeSVG = function () {
+    // this might be called while we're changing the main image
+    if (_self.osd.world.getItemCount() == 0) return;
+
+    var svgs = _self.svg.querySelectorAll(".annotationSVG"),
+      // upperLeftPoint,
+      // bottomRightPoint,
+      i,
+      w = _self.osd.world.getItemAt(0),
+      size = w.getContentSize(),
+      strokeScale = null;
+
+    // removed the if condition because the function would need to change if the window has been resized
+    _self.strokeWidthScale = _self.getStrokeWidthScaleFunction();
+
+    strokeScale = _self.strokeWidthScale(_self.osd.viewport.getZoom());
+    _self.changeStrokeScale(strokeScale);
+    _self.dispatchEvent("onChangeStrokeScale", {
+      strokeScale: strokeScale,
+    });
+
+    for (i = 0; i < svgs.length; i++) {
+      // upperLeftPoint = svgs[i].getAttribute("upperLeftPoint").split(",") || [];
+      // bottomRightPoint = svgs[i].getAttribute("bottomRightPoint").split(",") || [];
+      // if(upperLeftPoint.length == 0 || bottomRightPoint.length == 0){
+      //     continue;
+      // }
+      // upperLeftPoint = _self.osd.viewport.pixelFromPoint(new OpenSeadragon.Point(+upperLeftPoint[0], +upperLeftPoint[1]), true);
+      // bottomRightPoint = _self.osd.viewport.pixelFromPoint(new OpenSeadragon.Point(+bottomRightPoint[0], +bottomRightPoint[1]), true);
+
+      var ignoreReferencePoint =
+        svgs[i].getAttribute("ignoreReferencePoint") == "false" ? false : true;
+      var ignoreDimension =
+        svgs[i].getAttribute("ignoreDimension") == "false" ? false : true;
+      var scale = svgs[i].getAttribute("scale")
+        ? parseFloat(svgs[i].getAttribute("scale"))
+        : false;
+      var viewBox = svgs[i]
+        .getAttribute("viewBox")
+        .split(" ")
+        .map(function (value) {
+          return +value;
         });
-    }
+      // console.log(viewBox);
+      var topLeft = ignoreReferencePoint
+        ? { x: 0, y: 0 }
+        : { x: viewBox[0], y: viewBox[1] };
+      var bottomRight = ignoreDimension
+        ? { x: size.x, y: size.y }
+        : { x: topLeft.x + viewBox[2], y: topLeft.y + viewBox[3] };
+      // var topLeft = {x: _self.osd.world.getItemAt(1).getBounds(true).x + _self.osd.world.getItemAt(0).getBounds(true).x, y : 0 };
+      // var bottomRight = {x: topLeft.x + size.x, y : topLeft.y + size.y};
 
-    // Remove specific svg object by svgID
-    this.removeSVG = function(svgID){
-        var svgObj = this.svgCollection[svgID];
-
-        if(svgObj){
-            // remove all the groups, which contain annotations
-            svgObj.removeAllGroups();
-
-            // remove svg element
-            svgObj.svg.remove();
-
-            delete this.svgCollection[svgID];
+      // not ignoring the reference point and the scale is provided
+      if (scale) {
+        if (!ignoreReferencePoint) {
+          topLeft.x = topLeft.x / scale;
+          topLeft.y = topLeft.y / scale;
         }
-    }
-
-    // Remove overlay
-    this.removeOverlay = function (element) {
-        this.osd.removeOverlay(element);
-    }
-
-    // Remove mouse trackers for drawing
-    this.removeMouseTrackers = function(data){
-
-        if(this.mouseTrackers.length > 0){
-
-            while(this.mouseTrackers.length > 0){
-                var tracker = this.mouseTrackers.shift();
-                var userData = tracker.userData;
-
-                if(userData && userData.type != 'POLYGON'){
-                    this.dispatchSVGEvent("removeAnnotationByGraphID", {
-                        svgID : userData.svgID,
-                        groupID : userData.groupID,
-                        graphID : userData.graphID
-                    })
-                }
-
-                setTimeout(function(){
-                    tracker.destroy();
-                }, 300)
-            }
+        if (!ignoreDimension) {
+          bottomRight.x = bottomRight.x / scale;
+          bottomRight.y = bottomRight.y / scale;
         }
+      }
+      topLeft = w.imageToViewerElementCoordinates(
+        new OpenSeadragon.Point(topLeft.x, topLeft.y)
+      );
+      bottomRight = w.imageToViewerElementCoordinates(
+        new OpenSeadragon.Point(bottomRight.x, bottomRight.y)
+      );
+      svgs[i].setAttribute("x", topLeft.x + "px");
+      svgs[i].setAttribute("y", topLeft.y + "px");
+      svgs[i].setAttribute("width", bottomRight.x - topLeft.x + "px");
+      svgs[i].setAttribute("height", bottomRight.y - topLeft.y + "px");
+    }
+  };
+
+  // Save Anatomy SVG file
+  this.saveAnatomySVG = function (data) {
+    var svgID = data.svgID || "",
+      groupID = data.groupID,
+      rst = [];
+
+    if (this.svgCollection.hasOwnProperty(svgID)) {
+      rst = this.svgCollection[svgID].exportToSVG(groupID);
     }
 
-    this.resetSpinner = function (show) {
-        if (this.config.osd.spinnerID) {
-            var sp = document.querySelector("#" + this.config.osd.spinnerID);
-            if (sp) {
-                sp.style.display = (show ? 'block' : 'none');
-            }
-        }
+    _self.dispatchEvent("saveGroupSVGContent", rst);
+  };
+
+  // Set Openseadragon viewer item visibility
+  this.setItemVisibility = function (id, isDisplay) {
+    var item = this.osd.world.getItemAt(id),
+      opacity = isDisplay ? 1 : 0;
+    this.channels[id].setIsDisplay(isDisplay);
+    _self.renderChannelNamesOverlay();
+    item.setOpacity(opacity);
+
+    if (_self.config.osd.showHistogram) {
+      _self.osd.toggleColorHistogramBar(this.channels[id].name, isDisplay);
+    }
+  };
+
+  // Set Openseadragon viewer item channel values
+  this.setItemChannel = function (data) {
+    var channel = this.channels[data.id],
+      item = this.osd.world.getItemAt(data.id);
+    if (!channel || !item) {
+      return;
+    }
+    if ("settings" in data) {
+      channel.setMultiple(data.settings);
+    } else {
+      channel.set(data.type, data.value);
+    }
+
+    this.filters[data.id] = {
+      items: [item],
+      processors: channel.getFiltersList(data.init),
     };
 
-    // Reset the scalebar measurement (pixel per meter) with new value
-    this.resetScalebar = function (value) {
-
-        this.osd.scalebar({
-            location: OpenSeadragon.ScalebarLocation.BOTTOM_RIGHT,
-            pixelsPerMeter: value
-        });
+    var filters = [];
+    for (var key in this.filters) {
+      filters.push(this.filters[key]);
     }
 
-    // Reset Openseadragon to home view
-    this.resetHomeView = function () {
-        this.osd.viewport.goHome();
-        this.osd.viewport.applyConstraints();
+    this.osd.setFilterOptions({
+      filters: filters,
+    });
+
+    // the below one updates the last channel name as the filter for the osd. In case of multiple channels, this won't work.
+    // this.osd.setFilterOptions({
+    //     filters: [
+    //         {
+    //             items: [item],
+    //             processors: channel.getFiltersList()
+    //         }
+    //     ]
+    // })
+  };
+
+  // Set the viewer into different mode
+  this.setMode = function (data) {
+    // clear all the mouse tracker listeners
+    this.removeMouseTrackers();
+
+    switch (data.mode) {
+      case modes.ERASE_ANNOTATIONS:
+        _self.mode = modes.ERASE_ANNOTATIONS;
+        break;
+      case modes.VIEW:
+        _self.mode = modes.VIEW;
+        break;
+    }
+  };
+
+  // Zoom in to the given rectangle viewport
+  this.zoomInRectViewport = function (data) {
+    if (data == null) {
+      return;
     }
 
-    /**
-     * This function reads the URL param zoomLineThickness, and decides which stroke-width scale function to select
-     * log = the thickness vaires according to the log of the current zoom level. Since at each zoom in/out the zoom level changes by a factor of 2, i.e. it changes exponentially, therefore using a log approach provides linear change in line-thickness with respect to each zoom in/out click.
-     * default = using the original function, i.e. mapping the line thickness linearly with the total zoom levels avaibale in the OSD
-     * @return {function} the function is responsible for how the line-thickness vaires with respect of current zoom level
-     */
-    this.getStrokeWidthScaleFunction = function () {
-        switch (this.parameters.zoomLineThickness) {
-            case 'log':
-                return function (value) {
-                    var minZoom = _self.osd.viewport.getMinZoom();
-                    var maxZoom = _self.osd.viewport.getMaxZoom();
-                    var zoomLevels = Math.ceil(Math.log2(maxZoom) - Math.log2(minZoom));
-                    var currentZoomLevel = Math.ceil(Math.log2(value) - Math.log2(minZoom));
+    // Add 20% padding to each side
+    var x1 = data.x1 * 0.98,
+      y1 = data.y1 * 0.98,
+      x2 = data.x2 * 1.02,
+      y2 = data.y2 * 1.02;
 
-                    var delta = _self.strokeMaxScale - _self.strokeMinScale;
-                    var result = delta * currentZoomLevel / zoomLevels;
+    // Adjust Openseadragon viewer bounds to fit the group svg
+    this.osd.viewport.fitBounds(
+      new OpenSeadragon.Rect(x1, y1, x2 - x1, y2 - y1)
+    );
+  };
 
-                    return Math.max(_self.strokeMinScale, _self.strokeMaxScale - result);
-                };
-            default:
-                return d3.scaleLinear()
-                    .domain([_self.osd.viewport.getMinZoom(), _self.osd.viewport.getMaxZoom()])
-                    .range([_self.strokeMaxScale, _self.strokeMinScale])
-                    .nice();
-        }
+  // Zoom in
+  this.zoomIn = function () {
+    this.osd.viewport.zoomBy(2 / 1.0);
+    this.osd.viewport.applyConstraints();
+  };
+
+  // Zoom out
+  this.zoomOut = function () {
+    this.osd.viewport.zoomBy(1.0 / 2);
+    this.osd.viewport.applyConstraints();
+  };
+
+  /**
+   * used by savedAnnotationGroupState and discardAnnotationChange
+   * @type {Object}
+   */
+  this.savedAnnotationGroupStates = {};
+
+  /**
+   * This functions creates a copy of the SVG file of the annotation group that is being edited
+   * TODO there should be a mechanism to delete the unused savedAnnotationGroupStates objects
+   * @param {object} data contains the groupID and svgID of the annotation that is being edited
+   */
+  this.saveAnnotationGroupState = function (data) {
+    if (
+      !(data.svgID in this.svgCollection) ||
+      !(data.groupID in this.svgCollection[data.svgID].groups)
+    ) {
+      return;
     }
 
-    // Resize Annotation SVGs
-    this.resizeSVG = function(){
-        // this might be called while we're changing the main image
-        if (_self.osd.world.getItemCount() == 0) return;
+    var group = this.svgCollection[data.svgID].groups[data.groupID];
 
-        var svgs = _self.svg.querySelectorAll(".annotationSVG"),
-            // upperLeftPoint,
-            // bottomRightPoint,
-            i,
-            w = _self.osd.world.getItemAt(0),
-            size = w.getContentSize(),
-            strokeScale = null;
+    if (!(data.svgID in this.savedAnnotationGroupStates)) {
+      this.savedAnnotationGroupStates[data.svgID] = {};
+    }
+    this.savedAnnotationGroupStates[data.svgID][data.groupID] =
+      group.exportToSVG();
+  };
 
-        // removed the if condition because the function would need to change if the window has been resized
-        _self.strokeWidthScale = _self.getStrokeWidthScaleFunction();
+  /**
+   * This functions firsts deletes the annoation, and then re-loads it using the copy stored in this.savedAnnotationGroupStates
+   * TODO we shouldn't remove and create all the times, we should keep track of whether something changed or not
+   * @param {object} data contains the groupID and svgID of the annotation whoes edit is being cancelled
+   */
+  this.discardAnnotationGroupChanges = function (data) {
+    var svgID = data.svgID,
+      groupID = data.groupID;
 
-        strokeScale = _self.strokeWidthScale(_self.osd.viewport.getZoom())
-        _self.changeStrokeScale(strokeScale);
-        _self.dispatchEvent("onChangeStrokeScale", {
-            "strokeScale" : strokeScale
-        });
-
-        for(i = 0; i < svgs.length; i++){
-            // upperLeftPoint = svgs[i].getAttribute("upperLeftPoint").split(",") || [];
-            // bottomRightPoint = svgs[i].getAttribute("bottomRightPoint").split(",") || [];
-            // if(upperLeftPoint.length == 0 || bottomRightPoint.length == 0){
-            //     continue;
-            // }
-            // upperLeftPoint = _self.osd.viewport.pixelFromPoint(new OpenSeadragon.Point(+upperLeftPoint[0], +upperLeftPoint[1]), true);
-            // bottomRightPoint = _self.osd.viewport.pixelFromPoint(new OpenSeadragon.Point(+bottomRightPoint[0], +bottomRightPoint[1]), true);
-
-            var ignoreReferencePoint = svgs[i].getAttribute("ignoreReferencePoint") == "false" ? false : true;
-            var ignoreDimension = svgs[i].getAttribute("ignoreDimension") == "false" ? false : true;
-            var scale = svgs[i].getAttribute("scale") ? parseFloat(svgs[i].getAttribute("scale")) : false;
-            var viewBox = svgs[i].getAttribute("viewBox").split(" ").map(function(value){ return +value});
-            // console.log(viewBox);
-            var topLeft = ignoreReferencePoint ? {x: 0, y : 0 } : {x: viewBox[0], y : viewBox[1] };
-            var bottomRight = ignoreDimension ? {x: size.x, y : size.y } : {x: topLeft.x + viewBox[2], y : topLeft.y + viewBox[3]};
-            // var topLeft = {x: _self.osd.world.getItemAt(1).getBounds(true).x + _self.osd.world.getItemAt(0).getBounds(true).x, y : 0 };
-            // var bottomRight = {x: topLeft.x + size.x, y : topLeft.y + size.y};
-
-            // not ignoring the reference point and the scale is provided
-            if(scale){
-                if(!ignoreReferencePoint){
-                    topLeft.x = topLeft.x / scale;
-                    topLeft.y = topLeft.y / scale;
-                }
-                if(!ignoreDimension){
-                    bottomRight.x = bottomRight.x / scale;
-                    bottomRight.y = bottomRight.y / scale;
-                }
-            }
-            topLeft = w.imageToViewerElementCoordinates(new OpenSeadragon.Point(topLeft.x, topLeft.y));
-            bottomRight = w.imageToViewerElementCoordinates(new OpenSeadragon.Point(bottomRight.x, bottomRight.y));
-            svgs[i].setAttribute("x", topLeft.x + "px");
-            svgs[i].setAttribute("y", topLeft.y + "px");
-            svgs[i].setAttribute("width", bottomRight.x - topLeft.x + "px");
-            svgs[i].setAttribute("height", bottomRight.y - topLeft.y + "px");
-        }
+    // if the group has not been saved, we cannot do anything about it
+    if (
+      !(svgID in this.savedAnnotationGroupStates) ||
+      !(groupID in this.savedAnnotationGroupStates[svgID])
+    ) {
+      return;
     }
 
-    // Save Anatomy SVG file
-    this.saveAnatomySVG = function(data){
-        var svgID = data.svgID || "",
-            groupID = data.groupID,
-            rst = [];
-
-        if(this.svgCollection.hasOwnProperty(svgID)){
-            rst = this.svgCollection[svgID].exportToSVG(groupID);
-        };
-
-        _self.dispatchEvent("saveGroupSVGContent", rst);
+    // make sure the svgID is valid
+    if (!(svgID in this.svgCollection)) {
+      return;
     }
 
-    // Set Openseadragon viewer item visibility
-    this.setItemVisibility = function (id, isDisplay) {
-        var item = this.osd.world.getItemAt(id),
-            opacity = (isDisplay) ? 1 : 0;
-        this.channels[id].setIsDisplay(isDisplay);
-        _self.renderChannelNamesOverlay();
-        item.setOpacity(opacity);
+    var svgAnnotation = this.svgCollection[svgID],
+      savedState = this.savedAnnotationGroupStates[svgID][groupID];
 
-        if (_self.config.osd.showHistogram) {
-            _self.osd.toggleColorHistogramBar(this.channels[id].name, isDisplay);
-        }
+    if (svgAnnotation.groups[groupID]) {
+      // remove all the annotations under the group
+      svgAnnotation.groups[groupID].removeAllAnnotations();
+
+      // delete the group
+      delete svgAnnotation.groups[groupID];
     }
 
-    // Set Openseadragon viewer item channel values
-    this.setItemChannel = function (data) {
-        var channel = this.channels[data.id],
-            item = this.osd.world.getItemAt(data.id);
-        if (!channel || !item) { return; }
-        if ("settings" in data) {
-            channel.setMultiple(data.settings);
-        } else {
-            channel.set(data.type, data.value);
-        }
+    // add the saved state
+    var svgFile = new DOMParser().parseFromString(savedState, "image/svg+xml");
+    svgAnnotation.parseSVGNodes(svgFile.childNodes);
 
-        this.filters[data.id] = {
-          items: [item],
-          processors: channel.getFiltersList(data.init)
-        }
+    // make sure svg is rendered properly
+    this.resizeSVG();
 
-        var filters = [];
-        for (var key in this.filters){
-          filters.push(this.filters[key])
-        }
-
-        this.osd.setFilterOptions({
-          filters: filters
-        });
-
-        // the below one updates the last channel name as the filter for the osd. In case of multiple channels, this won't work.
-        // this.osd.setFilterOptions({
-        //     filters: [
-        //         {
-        //             items: [item],
-        //             processors: channel.getFiltersList()
-        //         }
-        //     ]
-        // })
-    }
-
-    // Set the viewer into different mode
-    this.setMode = function(data){
-        // clear all the mouse tracker listeners
-        this.removeMouseTrackers();
-
-        switch(data.mode){
-            case modes.ERASE_ANNOTATIONS:
-                _self.mode = modes.ERASE_ANNOTATIONS;
-                break;
-            case modes.VIEW:
-                _self.mode = modes.VIEW;
-                break;
-        }
-    }
-
-    // Zoom in to the given rectangle viewport
-    this.zoomInRectViewport = function(data){
-        if(data == null){ return }
-
-        // Add 20% padding to each side
-        var x1 = data.x1 * 0.980,
-            y1 = data.y1 * 0.980,
-            x2 = data.x2 * 1.020,
-            y2 = data.y2 * 1.020;
-
-        // Adjust Openseadragon viewer bounds to fit the group svg
-        this.osd.viewport.fitBounds(new OpenSeadragon.Rect(x1, y1, x2 - x1, y2 - y1));
-    }
-
-    // Zoom in
-    this.zoomIn = function () {
-        this.osd.viewport.zoomBy(2 / 1.0);
-        this.osd.viewport.applyConstraints();
-    }
-
-    // Zoom out
-    this.zoomOut = function () {
-        this.osd.viewport.zoomBy(1.0 / 2);
-        this.osd.viewport.applyConstraints();
-    }
-
-
-    /**
-     * used by savedAnnotationGroupState and discardAnnotationChange
-     * @type {Object}
-     */
-    this.savedAnnotationGroupStates = {};
-
-    /**
-     * This functions creates a copy of the SVG file of the annotation group that is being edited
-     * TODO there should be a mechanism to delete the unused savedAnnotationGroupStates objects
-     * @param {object} data contains the groupID and svgID of the annotation that is being edited
-     */
-    this.saveAnnotationGroupState = function (data) {
-        if (!(data.svgID in this.svgCollection) || !(data.groupID in this.svgCollection[data.svgID].groups)) {
-            return;
-        }
-
-        var group = this.svgCollection[data.svgID].groups[data.groupID];
-
-        if (!(data.svgID in this.savedAnnotationGroupStates)) {
-            this.savedAnnotationGroupStates[data.svgID] = {};
-        }
-        this.savedAnnotationGroupStates[data.svgID][data.groupID] = group.exportToSVG();
-    }
-
-    /**
-     * This functions firsts deletes the annoation, and then re-loads it using the copy stored in this.savedAnnotationGroupStates
-     * TODO we shouldn't remove and create all the times, we should keep track of whether something changed or not
-     * @param {object} data contains the groupID and svgID of the annotation whoes edit is being cancelled
-     */
-    this.discardAnnotationGroupChanges = function (data) {
-        var svgID = data.svgID, groupID = data.groupID;
-
-        // if the group has not been saved, we cannot do anything about it
-        if (!(svgID in this.savedAnnotationGroupStates) || !(groupID in this.savedAnnotationGroupStates[svgID])) {
-            return;
-        }
-
-        // make sure the svgID is valid
-        if (!(svgID in this.svgCollection)) {
-            return;
-        }
-
-        var svgAnnotation = this.svgCollection[svgID],
-            savedState = this.savedAnnotationGroupStates[svgID][groupID];
-
-        if (svgAnnotation.groups[groupID]) {
-            // remove all the annotations under the group
-            svgAnnotation.groups[groupID].removeAllAnnotations();
-
-            // delete the group
-            delete svgAnnotation.groups[groupID];
-        }
-
-        // add the saved state
-        var svgFile = new DOMParser().parseFromString(savedState, "image/svg+xml");
-        svgAnnotation.parseSVGNodes(svgFile.childNodes);
-
-        // make sure svg is rendered properly
-        this.resizeSVG();
-
-        // delete the saved state
-        delete savedState;
-    }
+    // delete the saved state
+    delete savedState;
+  };
 }

--- a/mview.html
+++ b/mview.html
@@ -80,6 +80,7 @@
     <script src="js/viewer/annotation/polygon.js"></script>
     <script src="js/viewer/annotation/rect.js"></script>
     <script src="js/viewer/annotation/line.js"></script>
+    <script src="js/viewer/annotation/arrowline.js"></script>
     <script src="js/viewer/annotation/circle.js"></script>
     <script src="js/config.js"></script>
     <script src="js/app.js"></script>


### PR DESCRIPTION
### Implementation

This pull request adds the arrow line annotation tool to the viewer app. To implement this functionality, I used the SVG line shape and added an arrowhead to the end of this line. This was done using the `marker-end` attribute that can be added to the `<line />` tag. In the `marker-end` attribute the URL of an SVG definition needs to be given. So, we create an SVG `marker` definition for the arrowhead, add it to the SVG definitions - `defs` tag and reference the URL for this in the line attribute.



### Changes

* Created `arrowline.js` to add the functionality of the new tool.
* `mview.html`: Loading the arrowline.js script
* `base.js`: Made changes to handle the `marker-end` attribute. It needs to be added only for the arrow line annotation type.
* `annotation-svg.js`: Added the code to add marker definition to the annotation SVG, changing the colour of the arrowhead on stroke change, parsing the saved arrow line annotations correctly and creating the corresponding marker SVG definitions for matching the stroke colours of the loaded arrow lines.
* `annotation-group.js`: Added the arrow line annotation type case.
* `annotation-tool.js`: HTML code changes to render the arrow line option in the tool and other arrow line case changes.


**Misc**
The PR might show other file changes, but those are due to the formatting being updated for the files. The exact lines for code changes are below:
* _mview.html_: Loading the arrow line script.
* _arrowline.js_: Created the entire file for the new annotation tool.
* _base.js_: Lines 24, 216-219
* _annotation-svg.js_: Lines 30-53,  75-79,  108-111, 409, 566-593
* _annotation-group.js_: Lines 51-53
* _annotation-tool.js_: Lines 86-88, 184