### PR TITLE
Added arrowline annotation tool

### DIFF
--- a/js/toolbar/annotation-tool.js
+++ b/js/toolbar/annotation-tool.js
@@ -84,6 +84,9 @@ function AnnotationTool(parent){
                 "<span class='toolBtn' data-type='LINE' title='Draw line'>",
                     "<i class='fa fa-minus'></i>",
                 "</span>",
+                "<span class='toolBtn' data-type='ARROWLINE' title='Draw arrow line'>",
+                    "<i class='fas fa-long-arrow-alt-right'></i>",
+                "</span>",
                 "<span class='toolBtn' data-type='POLYGON' title='Draw polygon'>",
                     "<i class='fas fa-draw-polygon'></i>",
                 "</span>",
@@ -171,6 +174,7 @@ function AnnotationTool(parent){
             case "CIRCLE":
             case "RECT":
             case "LINE":
+            case "ARROWLINE":
             case "POLYGON":
                 _self.dispatchEvent("drawingStart", {
                     svgID : _self.curSVGID,

--- a/js/viewer/annotation/annotation-group.js
+++ b/js/viewer/annotation/annotation-group.js
@@ -48,6 +48,9 @@ function AnnotationGroup(id, anatomy, description, parent){
             case "LINE":
                 annotation = new Line(attrs);
                 break;
+            case "ARROWLINE":
+                annotation = new ArrowLine(attrs);
+                break;
         };
 
         if(annotation != null){

--- a/js/viewer/annotation/arrowline.js
+++ b/js/viewer/annotation/arrowline.js
@@ -1,0 +1,39 @@
+function ArrowLine(attrs) {
+  attrs = attrs ? attrs : {};
+  Base.call(this, attrs);
+
+  // This tag needs to be line as the HTML tag used for arrow line is line itself
+  this._tag = "line";
+  this._attrs["x1"] = attrs["x1"] || null;
+  this._attrs["y1"] = attrs["y1"] || null;
+  this._attrs["x2"] = attrs["x2"] || null;
+  this._attrs["y2"] = attrs["y2"] || null;
+  this.svg = null;
+}
+
+ArrowLine.prototype = Object.create(Base.prototype);
+ArrowLine.prototype.constructor = ArrowLine;
+
+ArrowLine.prototype.insertPoint = function (point) {
+  var _self = this;
+  var updateAttrs = {};
+
+  if (_self._attrs.x1 == null || _self._attrs.y1 == null) {
+    // when the line is first added both the start and end point are assigned the same.
+    updateAttrs = {
+      x1: point.x,
+      y1: point.y,
+      x2: point.x,
+      y2: point.y,
+    };
+  } else {
+    updateAttrs = {
+      x2: point.x,
+      y2: point.y,
+      // This marker-end line adds the arrow-head to the line
+      "marker-end": "url(#arrow)",
+    };
+  }
+  _self.setAttributesByJSON(updateAttrs);
+  _self.renderSVG("arrowline");
+};

--- a/js/viewer/annotation/base.js
+++ b/js/viewer/annotation/base.js
@@ -20,7 +20,8 @@ function Base(attrs){
         "fill": "none", // TODO should this be part of added attributes as well?
         "stroke": this.constants.DEFAULT_SVG_STROKE,
         "stroke-width": this.constants.DEFAULT_SVG_STROKE_WIDTH,
-        "vector-effect": this.constants.DEFAULT_SVG_VECTOR_EFFECT
+        "vector-effect": this.constants.DEFAULT_SVG_VECTOR_EFFECT,
+        "marker-end": "url(#arrow)", //Added for the arrowline, this needs to be an attribute added to the HTML line tag
     }
 
     // the check that needs to be performed to prevent empty object
@@ -188,7 +189,7 @@ Base.prototype.highlight = function(highlightAttrs){
     }
 }
 
-Base.prototype.renderSVG = function(){
+Base.prototype.renderSVG = function(annotationType){
 
     var attr,
         value,
@@ -215,6 +216,10 @@ Base.prototype.renderSVG = function(){
 
     // add all the attributes
     for(attr in this._attrs){
+        // We skip the marker-end attribute if the annotation is not arrow line
+        if (attr == "marker-end" && annotationType !== "arrowline") {
+            continue;
+        }
         value = this._attrs[attr];
         if (attr === "stroke-width") {
             // TODO what if the value is not in pixel? (it can be pixel)

--- a/mview.html
+++ b/mview.html
@@ -80,6 +80,7 @@
     <script src="js/viewer/annotation/polygon.js"></script>
     <script src="js/viewer/annotation/rect.js"></script>
     <script src="js/viewer/annotation/line.js"></script>
+    <script src="js/viewer/annotation/arrowline.js"></script>
     <script src="js/viewer/annotation/circle.js"></script>
     <script src="js/config.js"></script>
     <script src="js/app.js"></script>


### PR DESCRIPTION
### Implementation

This pull request adds the arrow line annotation tool to the viewer app. To implement this functionality, I used the SVG line shape and added an arrowhead to the end of this line. This was done using the `marker-end` attribute that can be added to the `<line />` SVG shape. In the `marker-end` attribute the URL of an SVG marker definition needs to be given. So, we create an SVG `marker` definition for the arrowhead, add it to the SVG definitions - `defs` tag for the corresponding annotation SVG and reference the URL of the definition in the line's attribute.



### Changes

* Created `arrowline.js` to add the functionality of the new tool.
* `mview.html`: Loading the arrowline.js script
* `base.js`: Made changes to handle the `marker-end` attribute. It needs to be added only for the arrow line annotation type.
* `annotation-svg.js`: Added the code to add marker definition to the annotation SVG, changing the colour of the arrowhead on stroke change, parsing the saved arrow line annotations correctly and creating the corresponding marker SVG definitions for matching the stroke colours of the loaded arrow lines.
* `annotation-group.js`: Added the arrow line annotation type case.
* `annotation-tool.js`: HTML code changes to render the arrow line option in the tool and other arrow line case changes.