### PR TITLE
Properly report errors while loading images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 deployment-config.json
 .DS_Store
 data
+.vscode/*
+!.vscode/extensions.json

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -989,7 +989,15 @@ function Viewer(parent, config) {
             _self.osd.addTiledImage({
                 tileSource: tileSource,
                 compositeOperation: 'lighter',
-                opacity: (channel["isDisplay"] ? 1 : 0)
+                opacity: (channel["isDisplay"] ? 1 : 0),
+                error: function(event) {
+                    console.error("Failed to add tiled image:", event);
+                    _self.resetSpinner();
+                    _self.dispatchEvent('mainImageLoadFailed', {
+                        message: event.message,
+                        source: event.source
+                    });
+                }
             });
         }
 

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -984,18 +984,36 @@ function Viewer(parent, config) {
                 });
             }
 
-
             // add the image
             _self.osd.addTiledImage({
                 tileSource: tileSource,
                 compositeOperation: 'lighter',
                 opacity: (channel["isDisplay"] ? 1 : 0),
                 error: function(event) {
-                    console.error("Failed to add tiled image:", event);
+                    console.error('Failed to add the tiled image.');
+                    console.error(event);
+
+                     // Try to extract HTTP status from the event
+                     let errorMessage = event.message || 'Unknown error';
+                     
+                     // extract the status code
+                     let statusCode;
+                    if (event.source && event.source.ajaxHeaders) {
+                        statusCode = event.statusCode || event.status;
+                    }
+                    if (!statusCode && event.message) {
+                        const match = event.message.match(/HTTP\s+(\d{3})/i) || 
+                                    event.message.match(/status[:\s]+(\d{3})/i);
+                        if (match) {
+                            statusCode = parseInt(match[1]);
+                        }
+                    }
+
                     _self.resetSpinner();
                     _self.dispatchEvent('mainImageLoadFailed', {
-                        message: event.message,
-                        source: event.source
+                        event: event,
+                        status: statusCode,
+                        message: errorMessage
                     });
                 }
             });


### PR DESCRIPTION
This PR will make sure the errors reported by `addTiledImage` are properly dispatched to the client.

Unfortunately OSD is not exposing the actual HTTP error messages, so I had to do some string processing to find the HTTP status code from the error message.


P.S. The `add-item-failed` event was the correct event but we were attaching the handler on the world instead of the viewer, which I corrected in this PR.

Closes #112 