### PR TITLE
feat: Add search functionality to the channel list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+A 2D image viewer built on [OpenSeadragon](https://openseadragon.github.io/) with multi-channel image support, SVG annotation overlay, real-time color filtering, and an in-view scalebar. Primarily used inside an iframe within the [Chaise viewer app](https://github.com/informatics-isi-edu/chaise/tree/master/docs/user-docs/viewer/viewer-app.md) via `postMessage` cross-window communication.
+
+## Build & Deploy
+
+No build step — plain JavaScript with vendor libs committed in `vendor/`. No npm/node required for development.
+
+```bash
+make deploy          # rsync to /var/www/html/openseadragon-viewer/ (configurable via env vars)
+make help            # list available targets
+```
+
+Deploy env vars (all must have trailing `/`):
+- `WEB_URL_ROOT` (default `/`)
+- `WEB_INSTALL_ROOT` (default `/var/www/html/`)
+- `OSD_VIEWER_REL_PATH` (default `openseadragon-viewer/`)
+
+## Architecture
+
+**No module bundler or framework.** All JS files are loaded via `<script>` tags in `mview.html` (the entry point). Order matters — dependencies must appear before dependents.
+
+### Core Layers
+
+- **`js/app.js`** — Application singleton (`OSDViewer`). Initializes viewer + toolbar, routes events between them and the parent window (Chaise) via `dispatchEvent`/`receiveChaiseEvent` using `postMessage`.
+- **`js/config.js`** — Global config object (`_config`) passed to `OSDViewer`. Contains OSD settings, scalebar config, and annotation constants.
+- **`js/viewer/viewer.js`** — `Viewer` constructor. Manages OpenSeadragon instance, channels, SVG annotation overlays, zoom, image loading, and export.
+- **`js/toolbar/toolbar.controller.js`** — `ToolbarController`. Orchestrates toolbar sub-components (annotation tool, channel list, z-plane list).
+- **`js/toolbar/toolbar.view.js`** — `ToolbarView`. DOM rendering for toolbar menus and UI.
+
+### Sub-systems
+
+- **Channels** (`js/viewer/channel/`) — Multi-channel image compositing with per-channel color filters. `channel.js` manages individual channel state; `channel-filter.js` handles hue/intensity filtering.
+- **Annotations** (`js/viewer/annotation/`) — SVG-based drawing system. `annotation-group.js` groups annotations; `annotation-svg.js` manages the SVG overlay. Shape types (rect, circle, polygon, polyline, line, arrowline, path, text) each extend `base.js`.
+- **Toolbar components** (`js/toolbar/`) — `channel-list.js`/`channel-item.js` for channel UI, `annotation-tool.js` for drawing tools, `z-plane-list.js` for z-axis navigation.
+
+### Communication Pattern
+
+OSD viewer communicates with its parent (Chaise) via `window.postMessage`. The `app.js` `dispatchEvent` switch statement is the central routing hub — toolbar/viewer events that need to reach Chaise are forwarded as `postMessage`, and incoming Chaise messages are handled in `receiveChaiseEvent`. This is the most important file to understand for adding new cross-window features.
+
+### Vendor Libraries
+
+All in `vendor/`, no package manager. Key deps: OpenSeadragon, D3.js, jQuery 3.4.1, Bootstrap, Tippy.js (tooltips), noUiSlider, Font Awesome.

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ OSD_VIEWER_BASE_PATH:=$(WEB_URL_ROOT)$(OSD_VIEWER_REL_PATH)
 .PHONY: dist
 dist: ;
 
+# TODO while we're not doing anything to "build" we should eventually do
+#      so we created this placeholder that in the future will be implemented
+.PHONY: dist-wo-deps
+dist-wo-deps: ;
+
 .PHONY: deploy
 deploy: print_variables dont_deploy_in_root
 	$(info - deploying the package)

--- a/css/toolbar/channel-list.css
+++ b/css/toolbar/channel-list.css
@@ -62,7 +62,7 @@
 
 #menuContainer #navMenuContent .channelList .search-clear {
     position: absolute;
-    right: 50px;
+    right: 60px;
     top: 50%;
     transform: translateY(-50%);
     color: #888;

--- a/css/toolbar/channel-list.css
+++ b/css/toolbar/channel-list.css
@@ -81,7 +81,7 @@
 }
 
 #menuContainer #navMenuContent .channelList .channel-summary {
-    padding: 2px 10px;
+    padding: 10px;
     font-size: 12px;
     color: #888;
     text-align: left;

--- a/css/toolbar/channel-list.css
+++ b/css/toolbar/channel-list.css
@@ -15,9 +15,76 @@
 
 #menuContainer #navMenuContent .channelList .title-container {
     display: flex;
+    flex-direction: column;
+    padding-top: 5px;
+    position: sticky;
+    top: 0;
+    background: #1e1e1e;
+    z-index: 10;
+}
+
+#menuContainer #navMenuContent .channelList .title-header {
+    display: flex;
     justify-content: space-between;
     align-items: center;
-    padding-top: 5px;
+}
+
+#menuContainer #navMenuContent .channelList .search-container {
+    padding: 0px 10px;
+    position: relative;
+}
+
+#menuContainer #navMenuContent .channelList .search-input {
+    background: #2d2d2d;
+    color: #d9d6d6;
+    border: 1px solid #444;
+    padding: 6px 30px 6px 10px;
+    font-size: 14px;
+}
+
+#menuContainer #navMenuContent .channelList .search-input:focus {
+    background: #2d2d2d;
+    color: #d9d6d6;
+    border-color: #4674A7;
+    box-shadow: none;
+}
+
+#menuContainer #navMenuContent .channelList .search-input::placeholder {
+    color: #888;
+}
+
+#menuContainer #navMenuContent .channelList .input-group-addon {
+    background: #2d2d2d;
+    border: 1px solid #444;
+    border-left: none;
+    color: #888;
+}
+
+#menuContainer #navMenuContent .channelList .search-clear {
+    position: absolute;
+    right: 50px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #888;
+    cursor: pointer;
+    font-size: 14px;
+    display: none;
+    z-index: 10;
+}
+
+#menuContainer #navMenuContent .channelList .search-clear:hover {
+    color: #fff;
+}
+
+#menuContainer #navMenuContent .channelList .search-clear.visible {
+    display: block;
+}
+
+#menuContainer #navMenuContent .channelList .channel-summary {
+    padding: 2px 10px;
+    font-size: 12px;
+    color: #888;
+    text-align: left;
 }
 
 #menuContainer #navMenuContent .channelList .title-content {
@@ -80,4 +147,12 @@
     flex-direction: column;
     box-sizing: border-box;
     flex: 1;
+    overflow-y: auto;
+}
+
+#navMenuContent .channelList .no-results-message {
+    padding: 20px;
+    text-align: center;
+    color: #888;
+    font-style: italic;
 }

--- a/css/toolbar/menuContainer.css
+++ b/css/toolbar/menuContainer.css
@@ -25,6 +25,8 @@
 
 #menuContainer.expand {
     overflow-y: auto;
+    /* Reserve space for the scrollbar so Firefox doesn't overlap content */
+    scrollbar-gutter: stable;
 }
 
 #menuContainer #navMenu{
@@ -63,7 +65,6 @@
 
 #menuContainer #navMenuContent.expand{
     width: 300px; /* 285 + 15 */
-    padding-right: 15px; /* The reserved space for scrollbar */
     opacity: 1;
     display: flex;
     /* box-shadow: 0 0 5px #a29f9f; */

--- a/css/toolbar/menuContainer.css
+++ b/css/toolbar/menuContainer.css
@@ -67,6 +67,7 @@
     opacity: 1;
     display: flex;
     /* box-shadow: 0 0 5px #a29f9f; */
+    padding-bottom: 10px;
 }
 
 #menuContainer #navMenuContent .title{

--- a/js/config.js
+++ b/js/config.js
@@ -50,7 +50,21 @@ var _config = {
             barThickness: 3
         },
         constants: {
-            MAX_NUM_DEFAULT_CHANNEL: 5, // if there are more channels, they will be hidden by default.
+            DEFAULT_CHANNEL_LIST: {
+                /**
+                 * Threshold: the minimum number of pixels required for a channel to be considered "high volume".
+                 */
+                THRESHOLD: 10,
+                /**
+                 * If the channel list is considered high volume,
+                 * this dictates how many should be displayed on load.
+                 */
+                HIGH_VOLUME_COUNT: 1,
+                /**
+                 * If the channel list is considered low volume, this dictates how many should be displayed on load.
+                 */
+                LOW_VOLUME_COUNT: 5
+            },
             UNKNOWN_ANNNOTATION: 'UNKNOWN',
             STYLE_ATTRIBUTE_LIST: ['alignment-baseline', 'baseline-shift', 'clip', 'clip-path', 'clip-rule', 'color', 'color-interpolation', 'color-interpolation-filters', 'color-profile', 'color-rendering', 'cursor', 'direction', 'display', 'dominant-baseline', 'enable-background', 'fill', 'fill-opacity', 'fill-rule', 'filter', 'flood-color', 'flood-opacity', 'font-family', 'font-size', 'font-size-adjust', 'font-stretch', 'font-style', 'font-variant', 'font-weight', 'glyph-orientation-horizontal', 'glyph-orientation-vertical', 'image-rendering', 'kerning', 'letter-spacing', 'lighting-color', 'marker-end', 'marker-mid', 'marker-start', 'mask', 'opacity', 'overflow', 'pointer-events', 'shape-rendering', 'stop-color', 'stop-opacity', 'stroke', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'text-anchor', 'text-decoration', 'text-rendering', 'transform', 'transform-origin', 'unicode-bidi', 'vector-effect', 'visibility', 'word-spacing', 'writing-mode'],
             DEFAULT_SVG_STROKE_WIDTH: '1px',

--- a/js/toolbar/channel-item.js
+++ b/js/toolbar/channel-item.js
@@ -138,7 +138,15 @@ function ChannelItem(data) {
         })
         _self.elem.querySelector(".toggleVisibility").innerHTML = "<i class='"+_self.getIconClass("toggleDisplay")+"'></i>";
         _self.elem.querySelector(".toggleVisibility")._tippy.setContent(_self.getButtonTooltip('toggleDisplay'));
-        event.stopPropagation();
+
+        // Update channel list summary
+        if (_self.parent && _self.parent.onChannelDisplayChanged) {
+            _self.parent.onChannelDisplayChanged();
+        }
+
+        if (event && event.stopPropagation) {
+            event.stopPropagation();
+        }
     };
 
     /**
@@ -371,7 +379,7 @@ function ChannelItem(data) {
 
         // display
         if (_self.isDisplay != og.isDisplay) {
-            _self.onClickToggleDisplay(event, og.isExpand);
+            _self.onClickToggleDisplay(event, og.isDisplay);
         }
 
         // color settings

--- a/js/toolbar/channel-list.js
+++ b/js/toolbar/channel-list.js
@@ -7,6 +7,49 @@ function ChannelList(parent) {
     this.parent = parent || null;
     this.showChannelNamesOverlay = false;
 
+    /**
+     * The current search term used to filter the channel list.
+     * Empty string means no filter is active.
+     * @type {string}
+     */
+    this._searchTerm = '';
+
+    /**
+     * Check whether a channel is excluded by the current search filter.
+     * @param {string} id - The osdItemId of the channel to check.
+     * @returns {boolean} True if the channel does not match the search term and should be skipped.
+     */
+    this._isFilteredOut = function(id) {
+        if (!_self._searchTerm) return false;
+        return _self.collection[id].name.toLowerCase().indexOf(_self._searchTerm) === -1;
+    };
+
+    /**
+     * Update the tooltips on bulk action buttons to reflect
+     * whether a search filter is active (e.g. "all channels" vs "all matching channels").
+     * Also used during initial render to create the tippy instances.
+     */
+    this._updateBulkTooltips = function() {
+        var noun = _self._searchTerm ? 'matching channels' : 'channels';
+        var tooltips = {
+            '#save-all-channels': 'Save the current settings for all ' + noun,
+            '#reset-all-channels': 'Reset settings of all ' + noun,
+            '#collapse-all-channels': 'Collapse all ' + noun + ' controls',
+            '#expand-all-channels': 'Expand all ' + noun + ' controls',
+            '#hide-all-channels': 'Hide all ' + noun,
+            '#show-all-channels': 'Display all ' + noun,
+        };
+        for (var sel in tooltips) {
+            var el = _self.elem.querySelector(sel);
+            if (!el) continue;
+            if (el._tippy) {
+                el._tippy.setContent(tooltips[sel]);
+            } else {
+                tippy(el, { content: tooltips[sel] });
+            }
+        }
+    };
+
     // Add new channel items
     this.add = function(items) {
         var id,
@@ -67,30 +110,37 @@ function ChannelList(parent) {
 
     this.expandAllChannels = function (event) {
         for (var id in _self.collection) {
+            if (_self._isFilteredOut(id)) continue;
             _self.collection[id].onClickToggleExpand(event, true);
         }
     };
 
     this.collapseAllChannels = function (event) {
         for (var id in _self.collection) {
+            if (_self._isFilteredOut(id)) continue;
             _self.collection[id].onClickToggleExpand(event, false);
         }
     };
 
     this.showAllChannels = function (event) {
         for (var id in _self.collection) {
+            if (_self._isFilteredOut(id)) continue;
             _self.collection[id].onClickToggleDisplay(event, true);
         }
+        _self.updateChannelSummary();
     };
 
     this.hideAllChannels = function (event) {
         for (var id in _self.collection) {
+            if (_self._isFilteredOut(id)) continue;
             _self.collection[id].onClickToggleDisplay(event, false);
         }
+        _self.updateChannelSummary();
     };
 
     this.resetAllChannels = function (event) {
         for (var id in _self.collection) {
+            if (_self._isFilteredOut(id)) continue;
             _self.collection[id].resetChannelSettings(event);
         }
     };
@@ -102,6 +152,7 @@ function ChannelList(parent) {
         btn.className = "channels-control glyphicon glyphicon-refresh glyphicon-refresh-animate";
 
         for (var id in _self.collection) {
+            if (_self._isFilteredOut(id)) continue;
             if (_self.collection.hasOwnProperty(id) && _self.collection[id].acls.canUpdateConfig) {
                 data.push(_self.collection[id].saveChannelSettings(event, true));
             }
@@ -140,13 +191,98 @@ function ChannelList(parent) {
 
     }
 
+    this.filterChannels = function() {
+        var searchInput = _self.elem.querySelector('#channel-search-input');
+        var clearBtn = _self.elem.querySelector('#channel-search-clear');
+        var groupsContainer = _self.elem.querySelector('.groups');
+        var searchQuery = searchInput.value.toLowerCase().trim();
+        var matchCount = 0;
+        var noResultsMsg = _self.elem.querySelector('.no-results-message');
+
+        _self._searchTerm = searchQuery;
+
+        // Update clear button visibility
+        if (searchQuery.length > 0) {
+            clearBtn.classList.add('visible');
+        } else {
+            clearBtn.classList.remove('visible');
+        }
+
+        // Remove existing no results message if present
+        if (noResultsMsg) {
+            noResultsMsg.remove();
+        }
+
+        // Filter channels
+        for (var id in _self.collection) {
+            if (_self.collection.hasOwnProperty(id)) {
+                var item = _self.collection[id];
+                var itemName = item.name.toLowerCase();
+
+                if (searchQuery === '' || itemName.indexOf(searchQuery) !== -1) {
+                    item.elem.style.display = 'block';
+                    matchCount++;
+                } else {
+                    item.elem.style.display = 'none';
+                }
+            }
+        }
+
+        // Show empty state if no matches
+        if (matchCount === 0 && searchQuery !== '') {
+            var noResultsElem = document.createElement('div');
+            noResultsElem.className = 'no-results-message';
+            noResultsElem.textContent = 'No matching channels found';
+            groupsContainer.insertBefore(noResultsElem, groupsContainer.firstChild);
+        }
+
+        // Update summary and tooltips
+        _self.updateChannelSummary();
+        _self._updateBulkTooltips();
+    }
+
+    this.clearSearch = function() {
+        var searchInput = _self.elem.querySelector('#channel-search-input');
+        searchInput.value = '';
+        _self.filterChannels();
+    }
+
+    this.updateChannelSummary = function() {
+        var summaryElem = _self.elem.querySelector('#channel-summary');
+        if (!summaryElem) return;
+
+        var totalCount = 0;
+        var visibleCount = 0;
+        var displayedCount = 0;
+
+        for (var id in _self.collection) {
+            if (_self.collection.hasOwnProperty(id)) {
+                totalCount++;
+                var item = _self.collection[id];
+
+                if (!_self._isFilteredOut(id)) {
+                    visibleCount++;
+                    if (item.isDisplay) {
+                        displayedCount++;
+                    }
+                }
+            }
+        }
+
+        summaryElem.textContent = 'Found ' + visibleCount + ' of ' + totalCount + ' (' + displayedCount + ' Displayed)';
+    }
+
+    this.onChannelDisplayChanged = function() {
+        _self.updateChannelSummary();
+    }
+
 
     // Render the view
     this.render = function() {
 
-        var id,
-            collection = this.collection,
-            listElem = document.createElement("div");
+        const collection = this.collection;
+        const listElem = document.createElement("div");
+        let id;
 
         var channelHamburger = [
             '<span class="dropdown">',
@@ -174,18 +310,26 @@ function ChannelList(parent) {
         } else {
             listElem.innerHTML = [
                 "<div class='title-container'>",
-                    "<div class='title-content'>",
-                        "<span data-tippy-content='Hide the channel list' class='title' id='dismiss-channel-panel'>Channels</span>",
+                    "<div class='title-header'>",
+                        "<div class='title-content'>",
+                            "<span data-tippy-content='Hide the channel list' class='title' id='dismiss-channel-panel'>Channels</span>",
+                        "</div>",
+                        "<div class='all-channel-controls'>",
+                            "<span class='channels-control glyphicon glyphicon-saved' id='save-all-channels'></span>",
+                            "<span class='channels-control fas fa-undo' id='reset-all-channels'></span>",
+                            "<span class='channels-control fa fa-caret-up' id='collapse-all-channels'></span>",
+                            "<span class='channels-control fa fa-caret-down' id='expand-all-channels'></span>",
+                            "<span class='channels-control fa fa-eye-slash' id='hide-all-channels'></span>",
+                            "<span class='channels-control fa fa-eye' id='show-all-channels'></span>",
+                            channelHamburger.join(''),
+                        "</div>",
                     "</div>",
-                    "<div class='all-channel-controls'>",
-                        "<span data-tippy-content='Save the current settings for all the channels' class='channels-control glyphicon glyphicon-saved' id='save-all-channels'></span>",
-                        "<span data-tippy-content='Reset settings of all the channels' class='channels-control fas fa-undo' id='reset-all-channels'></span>",
-                        "<span data-tippy-content='Collapse all the channel controls' class='channels-control fa fa-caret-up' id='collapse-all-channels'></span>",
-                        "<span data-tippy-content='Expand all the channel controls' class='channels-control fa fa-caret-down' id='expand-all-channels'></span>",
-                        "<span data-tippy-content='Hide all the channels' class='channels-control fa fa-eye-slash' id='hide-all-channels'></span>",
-                        "<span data-tippy-content='Display all the channels' class='channels-control fa fa-eye' id='show-all-channels'></span>",
-                        channelHamburger.join(''),
+                    "<div class='search-container input-group'>",
+                        "<input type='text' id='channel-search-input' class='form-control search-input' placeholder='Search channels...' />",
+                        "<i class='fas fa-times search-clear' id='channel-search-clear'></i>",
+                        "<span class='input-group-addon'><i class='fas fa-search'></i></span>",
                     "</div>",
+                    "<div class='channel-summary' id='channel-summary'></div>",
                 "</div>",
                 "<div class='groups'></div>"
             ].join("");
@@ -213,21 +357,38 @@ function ChannelList(parent) {
 
         this.elem = listElem;
 
-        this.elem.querySelector('#expand-all-channels').addEventListener('click', this.expandAllChannels);
+        // Initialize tooltips for bulk action buttons
+        this._updateBulkTooltips();
 
-        this.elem.querySelector('#collapse-all-channels').addEventListener('click', this.collapseAllChannels);
+        // Attach event listeners only if elements exist
+        const expandAllBtn = this.elem.querySelector('#expand-all-channels');
+        const collapseAllBtn = this.elem.querySelector('#collapse-all-channels');
+        const showAllBtn = this.elem.querySelector('#show-all-channels');
+        const hideAllBtn = this.elem.querySelector('#hide-all-channels');
+        const resetAllBtn = this.elem.querySelector('#reset-all-channels');
+        const saveAllBtn = this.elem.querySelector('#save-all-channels');
+        const dismissBtn = this.elem.querySelector("#dismiss-channel-panel");
+        const toggleChannelNamesBtn = this.elem.querySelector('#toggle-channel-names');
+        const searchInput = this.elem.querySelector('#channel-search-input');
+        const searchClear = this.elem.querySelector('#channel-search-clear');
 
-        this.elem.querySelector('#show-all-channels').addEventListener('click', this.showAllChannels);
+        if (expandAllBtn) expandAllBtn.addEventListener('click', this.expandAllChannels);
+        if (collapseAllBtn) collapseAllBtn.addEventListener('click', this.collapseAllChannels);
+        if (showAllBtn) showAllBtn.addEventListener('click', this.showAllChannels);
+        if (hideAllBtn) hideAllBtn.addEventListener('click', this.hideAllChannels);
+        if (resetAllBtn) resetAllBtn.addEventListener('click', this.resetAllChannels);
+        if (saveAllBtn) saveAllBtn.addEventListener('click', this.saveAllChannels);
+        if (dismissBtn) dismissBtn.addEventListener('click', this.onClickedMenuHandler);
+        if (toggleChannelNamesBtn) toggleChannelNamesBtn.addEventListener('click', this.toggleChannelNames);
 
-        this.elem.querySelector('#toggle-channel-names').addEventListener('click', this.toggleChannelNames);
+        // Wire up search functionality
+        if (searchInput && searchClear) {
+            searchInput.addEventListener('input', this.filterChannels);
+            searchClear.addEventListener('click', this.clearSearch);
 
-        this.elem.querySelector('#hide-all-channels').addEventListener('click', this.hideAllChannels);
-
-        this.elem.querySelector('#reset-all-channels').addEventListener('click', this.resetAllChannels);
-
-        this.elem.querySelector('#save-all-channels').addEventListener('click', this.saveAllChannels);
-
-        this.elem.querySelector("#dismiss-channel-panel").addEventListener('click', this.onClickedMenuHandler);
+            // Initialize summary
+            this.updateChannelSummary();
+        }
 
     }
 }

--- a/js/toolbar/channel-list.js
+++ b/js/toolbar/channel-list.js
@@ -254,12 +254,16 @@ function ChannelList(parent) {
         var totalCount = 0;
         var visibleCount = 0;
         var displayedCount = 0;
+        let totalDisplayedCount = 0;
 
         for (var id in _self.collection) {
             if (_self.collection.hasOwnProperty(id)) {
                 totalCount++;
                 var item = _self.collection[id];
 
+                if (item.isDisplay) {
+                    totalDisplayedCount++;
+                }
                 if (!_self._isFilteredOut(id)) {
                     visibleCount++;
                     if (item.isDisplay) {
@@ -269,7 +273,16 @@ function ChannelList(parent) {
             }
         }
 
-        summaryElem.textContent = 'Found ' + visibleCount + ' of ' + totalCount + ' (' + displayedCount + ' Displayed) channels';
+        var tooltipText = displayedCount + ' channels in the search list';
+        if (displayedCount !== totalDisplayedCount) {
+            tooltipText += " (" + totalDisplayedCount + " total)";
+        }
+        tooltipText += ' are displayed in the image.';
+
+        summaryElem.innerHTML = 'Found ' + visibleCount + ' of ' + totalCount +
+            ' (<span class="displayed-count" data-tippy-content="' + tooltipText + '" data-tippy-placement="right">' +
+            displayedCount + ' Displayed</span>)';
+        tippy(summaryElem.querySelector('.displayed-count'), { maxWidth: 'none' });
     }
 
     this.onChannelDisplayChanged = function() {
@@ -325,7 +338,7 @@ function ChannelList(parent) {
                         "</div>",
                     "</div>",
                     "<div class='search-container input-group'>",
-                        "<input type='text' id='channel-search-input' class='form-control search-input' placeholder='Search channels...' />",
+                        "<input type='text' id='channel-search-input' class='form-control search-input' placeholder='Search channels' />",
                         "<i class='fas fa-times search-clear' id='channel-search-clear'></i>",
                         "<span class='input-group-addon'><i class='fas fa-search'></i></span>",
                     "</div>",

--- a/js/toolbar/channel-list.js
+++ b/js/toolbar/channel-list.js
@@ -269,7 +269,7 @@ function ChannelList(parent) {
             }
         }
 
-        summaryElem.textContent = 'Found ' + visibleCount + ' of ' + totalCount + ' (' + displayedCount + ' Displayed)';
+        summaryElem.textContent = 'Found ' + visibleCount + ' of ' + totalCount + ' (' + displayedCount + ' Displayed) channels';
     }
 
     this.onChannelDisplayChanged = function() {

--- a/js/toolbar/channel-list.js
+++ b/js/toolbar/channel-list.js
@@ -24,32 +24,6 @@ function ChannelList(parent) {
         return _self.collection[id].name.toLowerCase().indexOf(_self._searchTerm) === -1;
     };
 
-    /**
-     * Update the tooltips on bulk action buttons to reflect
-     * whether a search filter is active (e.g. "all channels" vs "all matching channels").
-     * Also used during initial render to create the tippy instances.
-     */
-    this._updateBulkTooltips = function() {
-        var noun = _self._searchTerm ? 'matching channels' : 'channels';
-        var tooltips = {
-            '#save-all-channels': 'Save the current settings for all ' + noun,
-            '#reset-all-channels': 'Reset settings of all ' + noun,
-            '#collapse-all-channels': 'Collapse all ' + noun + ' controls',
-            '#expand-all-channels': 'Expand all ' + noun + ' controls',
-            '#hide-all-channels': 'Hide all ' + noun,
-            '#show-all-channels': 'Display all ' + noun,
-        };
-        for (var sel in tooltips) {
-            var el = _self.elem.querySelector(sel);
-            if (!el) continue;
-            if (el._tippy) {
-                el._tippy.setContent(tooltips[sel]);
-            } else {
-                tippy(el, { content: tooltips[sel] });
-            }
-        }
-    };
-
     // Add new channel items
     this.add = function(items) {
         var id,
@@ -110,21 +84,18 @@ function ChannelList(parent) {
 
     this.expandAllChannels = function (event) {
         for (var id in _self.collection) {
-            if (_self._isFilteredOut(id)) continue;
             _self.collection[id].onClickToggleExpand(event, true);
         }
     };
 
     this.collapseAllChannels = function (event) {
         for (var id in _self.collection) {
-            if (_self._isFilteredOut(id)) continue;
             _self.collection[id].onClickToggleExpand(event, false);
         }
     };
 
     this.showAllChannels = function (event) {
         for (var id in _self.collection) {
-            if (_self._isFilteredOut(id)) continue;
             _self.collection[id].onClickToggleDisplay(event, true);
         }
         _self.updateChannelSummary();
@@ -132,7 +103,6 @@ function ChannelList(parent) {
 
     this.hideAllChannels = function (event) {
         for (var id in _self.collection) {
-            if (_self._isFilteredOut(id)) continue;
             _self.collection[id].onClickToggleDisplay(event, false);
         }
         _self.updateChannelSummary();
@@ -140,7 +110,6 @@ function ChannelList(parent) {
 
     this.resetAllChannels = function (event) {
         for (var id in _self.collection) {
-            if (_self._isFilteredOut(id)) continue;
             _self.collection[id].resetChannelSettings(event);
         }
     };
@@ -152,7 +121,6 @@ function ChannelList(parent) {
         btn.className = "channels-control glyphicon glyphicon-refresh glyphicon-refresh-animate";
 
         for (var id in _self.collection) {
-            if (_self._isFilteredOut(id)) continue;
             if (_self.collection.hasOwnProperty(id) && _self.collection[id].acls.canUpdateConfig) {
                 data.push(_self.collection[id].saveChannelSettings(event, true));
             }
@@ -236,9 +204,8 @@ function ChannelList(parent) {
             groupsContainer.insertBefore(noResultsElem, groupsContainer.firstChild);
         }
 
-        // Update summary and tooltips
+        // Update summary
         _self.updateChannelSummary();
-        _self._updateBulkTooltips();
     }
 
     this.clearSearch = function() {
@@ -273,11 +240,12 @@ function ChannelList(parent) {
             }
         }
 
-        var tooltipText = displayedCount + ' channels in the search list';
+        const single = displayedCount === 1;
+        var tooltipText = `${displayedCount} ${single ? 'channel' : 'channels'} in the search list`;
         if (displayedCount !== totalDisplayedCount) {
-            tooltipText += " (" + totalDisplayedCount + " total)";
+            tooltipText += ` (${totalDisplayedCount} total)`;
         }
-        tooltipText += ' are displayed in the image.';
+        tooltipText += ` ${single ? 'is' : 'are'} displayed in the image.`;
 
         summaryElem.innerHTML = 'Found ' + visibleCount + ' of ' + totalCount +
             ' (<span class="displayed-count" data-tippy-content="' + tooltipText + '" data-tippy-placement="right">' +
@@ -328,12 +296,12 @@ function ChannelList(parent) {
                             "<span data-tippy-content='Hide the channel list' class='title' id='dismiss-channel-panel'>Channels</span>",
                         "</div>",
                         "<div class='all-channel-controls'>",
-                            "<span class='channels-control glyphicon glyphicon-saved' id='save-all-channels'></span>",
-                            "<span class='channels-control fas fa-undo' id='reset-all-channels'></span>",
-                            "<span class='channels-control fa fa-caret-up' id='collapse-all-channels'></span>",
-                            "<span class='channels-control fa fa-caret-down' id='expand-all-channels'></span>",
-                            "<span class='channels-control fa fa-eye-slash' id='hide-all-channels'></span>",
-                            "<span class='channels-control fa fa-eye' id='show-all-channels'></span>",
+                            "<span data-tippy-content='Save the current settings for all channels' class='channels-control glyphicon glyphicon-saved' id='save-all-channels'></span>",
+                            "<span data-tippy-content='Reset settings of all channels' class='channels-control fas fa-undo' id='reset-all-channels'></span>",
+                            "<span data-tippy-content='Collapse all channel controls' class='channels-control fa fa-caret-up' id='collapse-all-channels'></span>",
+                            "<span data-tippy-content='Expand all channel controls' class='channels-control fa fa-caret-down' id='expand-all-channels'></span>",
+                            "<span data-tippy-content='Hide all channels' class='channels-control fa fa-eye-slash' id='hide-all-channels'></span>",
+                            "<span data-tippy-content='Show all channels' class='channels-control fa fa-eye' id='show-all-channels'></span>",
                             channelHamburger.join(''),
                         "</div>",
                     "</div>",
@@ -369,9 +337,6 @@ function ChannelList(parent) {
         });
 
         this.elem = listElem;
-
-        // Initialize tooltips for bulk action buttons
-        this._updateBulkTooltips();
 
         // Attach event listeners only if elements exist
         const expandAllBtn = this.elem.querySelector('#expand-all-channels');

--- a/js/toolbar/toolbar.view.js
+++ b/js/toolbar/toolbar.view.js
@@ -73,13 +73,13 @@ function ToolbarView(controller, config){
     // Render the annotation group menu
     this.renderChannelContent = function(channelList){
 
-        // Clear menu content
-        this._navMenuContentElem.innerHTML = "";
-        // Render channel list if it's null
+        // Render channel list if needed
         if(channelList.elem == null){
             channelList.render();
         }
-        // Append annotation list
+
+        // Clear menu content and append channel list
+        this._navMenuContentElem.innerHTML = "";
         this._navMenuContentElem.appendChild(channelList.elem);
 
         // make sure tooltips are added
@@ -102,19 +102,17 @@ function ToolbarView(controller, config){
     // Toggle menu content
     this.toggleDisplayMenuContent = function(type, object, forcedStateIsExpanded){
 
-        var expand = typeof forcedStateIsExpanded === "boolean" ? forcedStateIsExpanded : null;
-        if (expand === null) {
-            // we should toggle (so if it doesn't have expand then we have to add. or vise versa)
-            expand = this._navMenuContentElem.className.indexOf("expand") === -1;
-        }
+        const expand = typeof forcedStateIsExpanded === "boolean" ? forcedStateIsExpanded : null;
+        const currentlyExpanded = this._navMenuContentElem.className.indexOf("expand") !== -1;
+        const willExpand = expand !== null ? expand : !currentlyExpanded;
 
-        this._navMenuContentElem.className = expand ? "expand" : "";
+        this._navMenuContentElem.className = willExpand ? "expand" : "";
 
         // added to make sure the scroll is properly displayed
-        this._containerElem.className = expand ? "expand" : "";
+        this._containerElem.className = willExpand ? "expand" : "";
 
         // if it's expand, insert the content
-        if(expand){
+        if(willExpand){
             switch(type){
                 case "channelList":
                     this.renderChannelContent(object);

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -1015,8 +1015,13 @@ function Viewer(parent, config) {
                 // by default we're only channel name overlay for multi-channel images
                 _self._showChannelNamesOverlay = (params.info.length > 1);
 
-                // only show a few first
-                options["isDisplay"] = (i < _self.config.constants.MAX_NUM_DEFAULT_CHANNEL);
+                // only show the few first
+                const defVal = _self.config.constants.DEFAULT_CHANNEL_LIST;
+                const channelLimit =
+                  params.info.length > defVal.THRESHOLD
+                    ? defVal.HIGH_VOLUME_COUNT
+                    : defVal.LOW_VOLUME_COUNT;
+                options["isDisplay"] = (i < channelLimit);
 
                 // add to the list of channels
                 channel = new Channel(i, channelName, info.channelNumber, options);


### PR DESCRIPTION
Summary of changes:

  - Add search/filter functionality to the channel list
  - Make the channel list header (and search container) sticky
  - Change the heuristics for showing the channels:
    - If there are more than 10 channels, only display the first one.
    - If there are fewer than 10 channels, display the first 5.
 - Fix bug in `resetChannelSettings` where `og.isExpand` was used instead of `og.isDisplay` for toggling display
 - Fix how we're preserving space for the scrollbar of the channel list.
