### PR TITLE
feat: add the ability to append more channels

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -101,6 +101,17 @@ var OSDViewer = (function (_config) {
             case "updateGroupInfo":
                 toolbar && toolbar.updateDrawingGroupId(data);
                 break;
+            case "channelRemoved":
+                // Keep viewer.parameters.channels in sync: removing a channel here prevents
+                // getChannelInfo() from finding a stale entry if the same channel is re-added,
+                // which would cause duplicate matches and fall back to a wrong (index-based) name.
+                if (viewer && viewer.parameters && Array.isArray(viewer.parameters.channels) && data.channelNumber != null) {
+                    viewer.parameters.channels = viewer.parameters.channels.filter(function(ch) {
+                        return ch.channelNumber != data.channelNumber;
+                    });
+                }
+                window.parent.postMessage({messageType: type, content: data}, window.location.origin);
+                break;
             case "hideChannelList":
                 window.parent.postMessage({messageType: type, content: data}, window.location.origin);
                 break;
@@ -112,6 +123,9 @@ var OSDViewer = (function (_config) {
                 break;
             case "replaceChannelList":
                 toolbar && toolbar.replaceChannelList(data);
+                break;
+            case "addToChannelList":
+                toolbar && toolbar.addToChannelList(data);
                 break;
             case "onChangeStrokeScale":
                 window.parent.postMessage({messageType: type, content: data}, window.location.origin);
@@ -192,6 +206,13 @@ var OSDViewer = (function (_config) {
                     viewer.parameters.hasMore = data.hasMore;
                     viewer.parameters.totalChannelCount = data.totalChannelCount;
                     viewer.loadImages(data.mainImage, true);
+                    break;
+                case 'addChannels':
+                    // Append new channels without clearing existing ones.
+                    viewer.parameters.channels = (viewer.parameters.channels || []).concat(data.channels);
+                    viewer.parameters.hasMore = data.hasMore;
+                    viewer.parameters.totalChannelCount = data.totalChannelCount;
+                    viewer.addImages(data.mainImage, true);
                     break;
                 case 'updateZPlaneList':
                     toolbar && toolbar.updateZPlaneList(data);

--- a/js/toolbar/channel-list.js
+++ b/js/toolbar/channel-list.js
@@ -26,7 +26,7 @@ function ChannelList(parent) {
         return _self.collection[id].name.toLowerCase().indexOf(_self._searchTerm) === -1;
     };
 
-    // Add new channel items
+    // Add new channel items to this.collection. DOM rendering is the caller's responsibility.
     this.add = function(items) {
         var id,
             item,
@@ -52,11 +52,6 @@ function ChannelList(parent) {
                 });
 
                 this.collection[id] = item;
-
-                if (this.elem != null) {
-                    item.render();
-                    this.elem.querySelector(".groups").appendChild(item.elem);
-                }
             }
         }
     }
@@ -94,6 +89,14 @@ function ChannelList(parent) {
 
         this.render();
     }
+
+    this.addToList = function(data) {
+        this.add(data.channelList);
+        this.showChannelNamesOverlay = data.showChannelNamesOverlay;
+        this.hasMore = !!data.hasMore;
+        this.totalCount = data.totalCount || 0;
+        this.render();
+    };
 
     this.updateList = function (items) {
         this.add(items);
@@ -294,7 +297,7 @@ function ChannelList(parent) {
         tooltipText += ' ' + (renderedSingle ? 'is' : 'are') + ' rendered in the image.';
 
         summaryElem.innerHTML = [
-            `Added ${addedCount} of ${totalInDB} (${displayedCount} rendered)`,
+            `Added ${addedCount} of ${totalInDB} (${totalDisplayedCount} rendered)`,
             `<i class="fas fa-info-circle"></i>`
         ].join('');
 
@@ -325,6 +328,8 @@ function ChannelList(parent) {
         delete _self.collection[osdItemId];
 
         _self.filterChannels();
+        // channelNumber is included so app.js can remove this channel from viewer.parameters.channels
+        _self.dispatchEvent('channelRemoved', { osdItemId: osdItemId, channelNumber: item.number });
     }
 
 

--- a/js/toolbar/toolbar.controller.js
+++ b/js/toolbar/toolbar.controller.js
@@ -99,6 +99,15 @@ function ToolbarController(parent, config){
         }
     }
 
+    this.addToChannelList = function(data) {
+        this.channelList.addToList(data);
+        this._toolbarView.renderChannelContent(this.channelList, true);
+        if (Array.isArray(data.channelList) && data.channelList.length > 0) {
+            this.onClickedMenuHandler('channelList', true);
+            this.dispatchEvent('showChannelList');
+        }
+    };
+
     this.updateChannelConfigDone = function (data) {
         this.channelList.saveAllChannelsDone(data);
     }

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -1130,6 +1130,88 @@ function Viewer(parent, config) {
 
     }
 
+    // Append new channels and their images without clearing existing ones.
+    // Called in response to the 'addChannels' postMessage from Chaise.
+    this.addImages = function (params, hideByDefault) {
+        if (typeof params !== 'object' || !Array.isArray(params.info)) return;
+
+        var startIndex = Object.keys(_self.channels).length;
+        var channelList = [];
+
+        _self.resetSpinner(true);
+        _self._showChannelNamesOverlay = (startIndex + params.info.length) > 1;
+
+        for (var i = 0; i < params.info.length; i++) {
+            var info = params.info[i];
+            var osdIndex = startIndex + i;
+            var channelInfo = _self.getChannelInfo(info.channelNumber);
+
+            var channelName = channelInfo.channelName ? channelInfo.channelName : '';
+            if (channelInfo.aliasName) channelName = channelInfo.aliasName;
+            if (typeof channelName !== 'string' || channelName.length === 0) channelName = osdIndex.toString();
+
+            var options = {};
+            if (typeof channelInfo.pseudoColor === 'string') {
+                var hexToRGB = _self._utils.colorHexToRGB(channelInfo.pseudoColor);
+                options.pseudoColor = hexToRGB ? hexToRGB : channelInfo.pseudoColor;
+            }
+            if (typeof channelInfo.isRGB === 'boolean') options.isRGB = channelInfo.isRGB;
+            if (typeof channelInfo.channelConfig === 'object' && channelInfo.channelConfig != null) options.channelConfig = channelInfo.channelConfig;
+            if (typeof channelInfo.acls === 'object' && channelInfo.acls != null) options.acls = channelInfo.acls;
+            options.isMultiChannel = true;
+            options.isDisplay = !hideByDefault;
+
+            var channel = new Channel(osdIndex, channelName, info.channelNumber, options);
+            _self.channels[osdIndex] = channel;
+
+            channelList.push({
+                number: info.channelNumber,
+                name: channel.name,
+                blackLevel: channel.blackLevel,
+                whiteLevel: channel.whiteLevel,
+                gamma: channel.gamma,
+                saturation: channel.saturation,
+                hue: channel.hue,
+                displayGreyscale: channel.displayGreyscale,
+                osdItemId: channel.id,
+                isDisplay: channel.isDisplay,
+                acls: options.acls,
+            });
+
+            var tileSource;
+            var url = info.url;
+            if (url.indexOf('ImageProperties.xml') !== -1) {
+                var xmlString = _self._utils.getUrlContent(url);
+                var imgPath = url.replace('/ImageProperties.xml', '');
+                var xmlDoc = new DOMParser().parseFromString(xmlString.trim(), 'application/xml');
+                xmlDoc = xmlDoc.getElementsByTagName('IMAGE_PROPERTIES')[0];
+                tileSource = _self.buildTileSource(xmlDoc, imgPath);
+            } else if (url.indexOf('info.json') !== -1) {
+                tileSource = url;
+            } else {
+                tileSource = { type: 'image', url: url };
+            }
+
+            _self.osd.addTiledImage({
+                tileSource: tileSource,
+                compositeOperation: 'lighter',
+                opacity: (channel["isDisplay"] ? 1 : 0),
+            });
+        }
+
+        if (params.info.length === 0 || hideByDefault) {
+            _self.resetSpinner();
+            _self.renderChannelNamesOverlay();
+        }
+
+        _self.dispatchEvent('addToChannelList', {
+            channelList: channelList,
+            showChannelNamesOverlay: _self._showChannelNamesOverlay,
+            hasMore: _self.parameters.hasMore,
+            totalCount: _self.parameters.totalChannelCount,
+        });
+    };
+
     // Show tooltip when mouse over the annotation on Openseadragon viewer
     this.onMouseoverShowTooltip = function(data){
 


### PR DESCRIPTION
This PR adds support for appending channels at runtime:

- New `addImages(params, hideByDefault)` function in `viewer.js` appends channels to the existing list without clearing state; new channels default to hidden and collapsed when `hideByDefault` is true
- `app.js` handles the new `addChannels` postMessage, updating `viewer.parameters.channels` and calling `addImages`
- `channelRemoved` dispatch now includes `channelNumber`; `app.js` uses it to keep `viewer.parameters.channels` in sync, fixing wrong channel names when re-adding a removed channel
- `ChannelList.add()` now only populates `collection`; `addToList` calls `render()` afterward — fixes the stale "No channels added" message, wrong channel count, and missing drag handle on the first added item
- `ToolbarController.addToChannelList` method added to route the `addToChannelList` event from the viewer to the channel list