### PR TITLE
Add the ability to rotate images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ deployment-config.json
 data
 .vscode/*
 !.vscode/extensions.json
+
+# Claude Code user-local settings (personal permissions, env vars, etc.)
+.claude/settings.local.json

--- a/css/zAxisPreview.css
+++ b/css/zAxisPreview.css
@@ -14,11 +14,10 @@
 
 .z-planes-container .z-plane-slider {
 	height: 25px;
-	width: auto;
+	width: 400px;
 	text-align: center;
 	font-size: 14px;
 	display: flex;
-	align-items: center;
 	justify-content: center;
 	padding-top: 5px;
 	position: relative;
@@ -192,22 +191,6 @@ input.slider{
 	border-top: 1px solid black;
 	border-bottom: 1px solid black;
 	border-left: 1px solid black;
-}
-
-.z-planes-container .z-plane-slider .update-thumbnails-btn {
-	height: 21px;
-	margin-left: 10px;
-	padding: 0 8px;
-	background-color: rgb(70, 116, 167);
-	color: white;
-	border: 1px solid black;
-	border-radius: 4px;
-	cursor: pointer;
-	font-size: 12px;
-	line-height: 1;
-	display: inline-flex;
-	align-items: center;
-	gap: 5px;
 }
 
 .z-planes-container .z-plane-info-container .info-buttom-container:last-child {

--- a/css/zAxisPreview.css
+++ b/css/zAxisPreview.css
@@ -271,6 +271,7 @@ input.slider{
 }
 
 
+/* centers the thumbnail and clips it to the box (e.g. when rotated) */
 .z-planes-container .z-plane-carousel .z-plane-container .z-plane .z-plane-thumb-wrapper {
 	height: 100%;
 	display: flex;

--- a/css/zAxisPreview.css
+++ b/css/zAxisPreview.css
@@ -193,6 +193,12 @@ input.slider{
 	border-left: 1px solid black;
 }
 
+.z-planes-container .z-plane-info-container .update-thumbnails-btn {
+	color: white;
+	margin-right: 5px;
+	border: 1px solid black;
+}
+
 .z-planes-container .z-plane-info-container .info-buttom-container:last-child {
 	border-top-right-radius: 4px;
 	border-bottom-right-radius: 4px;

--- a/css/zAxisPreview.css
+++ b/css/zAxisPreview.css
@@ -14,10 +14,11 @@
 
 .z-planes-container .z-plane-slider {
 	height: 25px;
-	width: 400px;
+	width: auto;
 	text-align: center;
 	font-size: 14px;
 	display: flex;
+	align-items: center;
 	justify-content: center;
 	padding-top: 5px;
 	position: relative;
@@ -193,10 +194,20 @@ input.slider{
 	border-left: 1px solid black;
 }
 
-.z-planes-container .z-plane-info-container .update-thumbnails-btn {
+.z-planes-container .z-plane-slider .update-thumbnails-btn {
+	height: 21px;
+	margin-left: 10px;
+	padding: 0 8px;
+	background-color: rgb(70, 116, 167);
 	color: white;
-	margin-right: 5px;
 	border: 1px solid black;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 12px;
+	line-height: 1;
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
 }
 
 .z-planes-container .z-plane-info-container .info-buttom-container:last-child {
@@ -277,8 +288,17 @@ input.slider{
 }
 
 
+.z-planes-container .z-plane-carousel .z-plane-container .z-plane .z-plane-thumb-wrapper {
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	overflow: hidden;
+}
+
 .z-planes-container .z-plane-carousel .z-plane-container .z-plane .z-plane-image {
 	height: 100%;
+	transform-origin: center;
 }
 
 .z-planes-container .z-plane-carousel .z-plane-container .z-plane .z-plane-id {

--- a/docs/dev-docs/annotation-file.md
+++ b/docs/dev-docs/annotation-file.md
@@ -6,9 +6,11 @@ In this document, we will go over what the output SVG for each drawing tool look
 - [Drawings](#drawings)
   - [Path](#path)
   - [Rectangle](#rectangle)
+  - [Circle](#circle)
   - [Line](#line)
   - [Arrow line](#arrow-line)
   - [Polygon](#polygon)
+  - [Polyline](#polyline)
   - [Text](#text)
 
 
@@ -75,6 +77,18 @@ example:
 - The `x`, `y`, `width`, and `height` are required for drawing the rectangle. Refer to [this page](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/rect) for more information.
 - `fill="None"` and `stroke` will ensure displaying proper color. As we mentioned before, this value must be consistent with all the other drawings in this group.
 
+### Circle
+
+```html
+<circle cx="<CENTER_X_VALUE>" cy="<CENTER_Y_VALUE>" r="<RADIUS>" fill="None" stroke="<COLOR_VALUE>"></circle>
+
+example:
+<circle cx="223.0991430260047" cy="138.40684101654847" r="48.989762789621246" fill="None" stroke="#d5ff00"></circle>
+```
+
+- The `cx`, `cy`, and `r` are required for drawing the circle. Refer to [this page](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/circle) for more information.
+- `fill="None"` and `stroke` will ensure displaying proper color. As we mentioned before, this value must be consistent with all the other drawings in this group.
+
 ### Line
 
 ```html
@@ -131,6 +145,20 @@ example:
 - `fill="None"` and `stroke` will ensure displaying proper color. As we mentioned before, this value must be consistent with all the other drawings in this group.
 
 
+### Polyline
+
+A polyline is like a polygon but the path is left open (the last point is not connected back to the first).
+
+```html
+<polyline fill="None" stroke="<COLOR_VALUE>" points="<POINT_X_AND_Y_COMBO>"></polyline>
+
+example:
+<polyline fill="None" stroke="#d5ff00" points="130.1237071513002,431.6493794326241 251.90115248226948,391.31567671394794 231.10121158392434,447.7095153664302"></polyline>
+```
+- The `points` are required for drawing the polyline. Refer to [this page](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/polyline) for more information.
+- `fill="None"` and `stroke` will ensure displaying proper color. As we mentioned before, this value must be consistent with all the other drawings in this group.
+
+
 ### Text
 
 Since we wanted to ensure we're fully honoring the spacing, we're not using the SVG's `text` element but instead `foreignObject` with a `p` tag inside it. The following is an example of it:
@@ -161,4 +189,17 @@ example:
   - As we mentioned before, the `stroke` value must be consistent with all the other drawings in this group.
 - The `font-size` must be defined on the `p` tag.
 - Other styles on the `p` tag are not needed for openseadragon-viewer as we're going to override and inject those values. But for consistency it's better if you include them in your SVG.
+- The live editor uses a `contenteditable` `<div>`, but the saved format is always `foreignObject > p` as shown above.
+
+#### Rotation
+
+If the annotation was created while the viewport was rotated, the `p` tag also carries an inline rotation so the text stays "stuck" to the image orientation it was created in:
+
+```html
+<p style="... transform: rotate(-90deg); transform-origin: 0 0;">Test</p>
+```
+
+- `transform: rotate(-R0deg)` where `R0` is the viewport rotation (in degrees) at creation time, and `transform-origin: 0 0`.
+- This is optional: omit it (or use `rotate(0deg)`) for text that was created with no rotation.
+- On import these values are preserved as-is. Note that, unlike text, the shape drawings above store **no** rotation. They are kept in image-space coordinates and re-rotated dynamically by the viewer. See [annotation-tool.md](annotation-tool.md#rotation) for the full behavior.
 

--- a/docs/dev-docs/annotation-tool.md
+++ b/docs/dev-docs/annotation-tool.md
@@ -24,6 +24,10 @@ This document will summarize the implementation details related to annotation to
   - [Notable Updates](#notable-updates)
   - [Fixes and Adjustments](#fixes-and-adjustments)
   - [Additional Resources](#additional-resources-1)
+- [Rotation](#rotation)
+  - [Shapes](#shapes)
+  - [Text](#text-rotation)
+  - [Export to image](#export-to-image)
 
 
 ## Text Annotation
@@ -56,19 +60,21 @@ Users can place the annotation anywhere on the image with a simple mouse click. 
 
 **Code Logic:**
 
-With the text annotation mode enabled, a user's click on the canvas checks for any previously drawn text annotation. If one exists, we transform the previous annotation into a text (`<p>` tag). This transformation involves removing the `div` containing the input textarea and appending the `p` tag with the same attributes and styling as the textarea to the foreign object. We then create a new text annotation object, and new mouse trackers are added to listen for the user's click event to place the annotation on the image. The `onMouseClickToDraw` function in `viewer.js` handles these functionalities.
+With the text annotation mode enabled, a user's click on the canvas checks for any previously drawn text annotation. If one exists, we transform the previous annotation into a text (`<p>` tag). This transformation involves removing the editable input and appending a `p` tag with the same attributes and styling to the foreign object. We then create a new text annotation object, and new mouse trackers are added to listen for the user's click event to place the annotation on the image. The `onMouseClickToDraw` function in `viewer.js` handles these functionalities.
+
+> **Note on the editable input.** The live editor is a `contenteditable` `<div>` (`.text-foreign-object-input`), not a `<textarea>`. The DOM is `foreignObject > div.text-foreign-object-div > div.text-foreign-object-input`. A plain `<div>` is used because native form widgets like `<textarea>` are rendered in a way that bypasses CSS transforms on ancestor SVGs, so their text would not rotate with the rest of the annotation overlay (see [Rotation](#rotation)). The finalized/saved annotation is always a `<p>`.
 
 #### Text Input Interaction
 
 Once the annotation is positioned, the user can interact with it in several ways:
 
-1. **Text Entry**: Users can input their desired text into the text area.
-2. **Annotation Movement**: Users can relocate the annotation across the canvas by clicking and dragging the text area borders.
+1. **Text Entry**: Users can input their desired text into the text input.
+2. **Annotation Movement**: Users can relocate the annotation across the canvas by clicking and dragging the wrapper borders.
 3. **Text Box Resizing**: Users can adjust the horizontal dimensions of the text box by dragging the resize control.
 
 **Code Logic:**
 
-The `text.js` file contains all the functions that handle text interaction. For text entry, the textarea manages the input functionality. Event listeners on the input event adjust the textarea's height after each input change to accommodate the text as it shifts to a new line. The drag functionality, or annotation movement, is handled by the event handlers on the `mouseover` event of the `div` containing the textarea. The application performs basic arithmetic computation to accurately adjust the `div`'s position. The resize control handles the text box resizing, listening for the same event and adjusting the width of the `div` containing the textarea accordingly. These functionalities are elaborated in detail within the code comments.
+The `text.js` file contains all the functions that handle text interaction. For text entry, the contenteditable input `<div>` manages the input functionality; an `input` event listener adjusts its height after each change so it grows as the text wraps to a new line. The drag functionality, or annotation movement, is handled by `onmousedown`/`onpointerdown` on the wrapper `div` (`.text-foreign-object-div`); the actual move then listens on document-level `pointermove`/`pointerup` so the drag stays valid even when the cursor leaves the div, and the application performs basic arithmetic to adjust the `div`'s position. The resize control handles the text box resizing via a `mousedown` listener, adjusting the width of the wrapper `div` accordingly. These functionalities are elaborated in detail within the code comments.
 
 
 
@@ -143,3 +149,47 @@ For a more comprehensive understanding and deeper insights into the Arrow Line A
 2. [OpenSeadragon Viewer Pull Request #100](https://github.com/informatics-isi-edu/openseadragon-viewer/pull/100)
 
 These links can provide further context and discussions that were crucial to the design and implementation of the Arrow Line Annotation feature.
+
+
+
+## Rotation
+
+The viewport can be rotated, and the annotation overlay rotates with it. Rotation is driven by OpenSeadragon's viewport: `viewer.rotateBy(degrees)` applies a relative rotation and `viewer.resetRotation(degrees)` sets an absolute one (both in `viewer.js`). These are triggered by the `rotate` and `resetRotation` `postMessage`s from Chaise (routed in `app.js`). An initial rotation can be persisted through `imageConfig.rotate`, which is applied at load time (before annotations are imported) so the overlay is positioned correctly from the first paint.
+
+Whenever the viewport changes (zoom, pan, or rotate), the `resizeSVG` function in `viewer.js` repositions and re-transforms every `.annotationSVG` overlay. For rotation it sets a single CSS transform on each `.annotationSVG`:
+
+```js
+// rotate the overlay around its screen-space top-left corner
+svg.style.transform =
+  "translate(" + scrTL.x + "px, " + scrTL.y + "px) " +
+  "rotate(" + rotation + "deg) " +
+  "translate(" + (-scrTL.x) + "px, " + (-scrTL.y) + "px)";
+```
+
+The triple `translate → rotate → translate` rotates around the overlay's screen-space top-left (canvas/CSS rotation otherwise pivots on the origin).
+
+### Shapes
+
+`rect`, `circle`, `line`, `path`, `polygon`, `polyline`, and `arrowline` need no per-shape handling. Their geometry stays in image-space coordinates (the SVG `viewBox`), and the single CSS transform on the parent `.annotationSVG` rotates them all together. Because the rotation lives only in CSS on the overlay element, it is **not** written into the saved SVG: shape coordinates are stored un-rotated and are re-rotated dynamically on each load.
+
+### Text (rotation)
+
+Text is the exception, because its content lives in a `foreignObject` and is meant to stay readable.
+
+- **While editing:** the editable wrapper (`.text-foreign-object-div`) is counter-rotated with `rotate(-R)` (where `R` is the current viewport rotation), so the user always types upright regardless of how the image is rotated. `resizeSVG` re-applies this counter-rotation on every rotation change.
+- **On finalize:** when the annotation is committed to a `<p>`, `transform()` bakes `rotate(-R0)` plus `transform-origin: 0 0` into the `<p>`'s inline style, where `R0` is the viewport rotation at creation time. The net visible rotation then becomes `R - R0`, so the text "sticks" to the image's orientation at the moment it was created: create text at `R0 = 90°` and it stays aligned to that orientation as the viewport keeps rotating.
+- **On import:** the baked `transform`/`transform-origin` are read from the saved style and re-applied in `createPTag`, so a reloaded annotation keeps its original orientation instead of being recomputed against the current rotation.
+
+Unlike shapes, this rotation **is** persisted: the saved `<p>` carries the inline `transform`. See [annotation-file.md](annotation-file.md#text) for the saved format.
+
+### Export to image
+
+Exporting a screenshot (`exportViewToJPG` in `viewer.js`) rasterizes the OSD canvas plus every annotation SVG into one image. CSS transforms set by `resizeSVG` do not survive `XMLSerializer`, so each SVG is cloned with its transform stripped (`svgClone.style.transform = ''`) and the rotation is re-applied on the 2D canvas context with the same pivot technique:
+
+```js
+newCtx.translate(dims[0], dims[1]);
+newCtx.rotate(rotationRad);          // getRotation() is degrees; canvas wants radians
+newCtx.translate(-dims[0], -dims[1]);
+```
+
+Text orientation is already correct because the baked `<p>` transform travels with the serialized SVG. The export also inlines computed font properties onto each `<p>` and forces `overflow: visible` on cloned `foreignObject`s, since the external CSS that normally provides those is not available during standalone rasterization.

--- a/js/app.js
+++ b/js/app.js
@@ -242,7 +242,9 @@ var OSDViewer = (function (_config) {
                     viewer.rotateBy(rotateDegrees);
                     break;
                 case 'resetRotation':
-                    viewer.resetRotation();
+                    // optional content { degrees }: the saved default to return to (0 if omitted)
+                    var resetDegrees = data && typeof data.degrees === 'number' ? data.degrees : 0;
+                    viewer.resetRotation(resetDegrees);
                     break;
                 case 'downloadView':
                     viewer.exportViewToJPG(data);

--- a/js/app.js
+++ b/js/app.js
@@ -235,6 +235,15 @@ var OSDViewer = (function (_config) {
                 case 'homeView':
                     viewer.resetHomeView();
                     break;
+                case 'rotate':
+                    // data is the optional content object: { degrees: number }.
+                    // Defaults to -90 (one counterclockwise step) when omitted.
+                    var rotateDegrees = data && typeof data.degrees === 'number' ? data.degrees : -90;
+                    viewer.rotateBy(rotateDegrees);
+                    break;
+                case 'resetRotation':
+                    viewer.resetRotation();
+                    break;
                 case 'downloadView':
                     viewer.exportViewToJPG(data);
                     break;

--- a/js/toolbar/z-plane-list.js
+++ b/js/toolbar/z-plane-list.js
@@ -130,7 +130,7 @@ function ZPlaneList(parent) {
         // Cache the main image dimensions so we can recompute the thumbnail
         // width when the viewport rotation changes (the rotated image's
         // aspect ratio is the inverse of the original).
-        if (data.mainImageWidth > 0 & data.mainImageHeight > 0) {
+        if (data.mainImageWidth > 0 && data.mainImageHeight > 0) {
             _self._mainImageWidth = data.mainImageWidth;
             _self._mainImageHeight = data.mainImageHeight;
             _self._updateThumbnailWidth();
@@ -600,9 +600,11 @@ function ZPlaneList(parent) {
             var thumbHeight = _self._thumbnailProperties.height;
             var maxWidth = _self._thumbnailProperties.maxWidth;
 
-            // Every thumbnail tracks the current viewport rotation. The <img>
-            // is always at the un-rotated native size; the wrapper is the
-            // rotated AABB and the inner <img> gets the CSS transform.
+            /*
+             * Thumbnails track the viewport rotation. A CSS transform doesn't change the
+             * layout box, so the <img> gets the transform at native size while the wrapper
+             * is sized to the rotated AABB — keeping the carousel layout gap-free and clipped.
+             */
             var rotation = _self._getCurrentRotation();
             var wrapperWidth = _self._getThumbnailWidthForRotation(rotation);
             var transform = _self._getThumbnailTransform(rotation);

--- a/js/toolbar/z-plane-list.js
+++ b/js/toolbar/z-plane-list.js
@@ -136,18 +136,15 @@ function ZPlaneList(parent) {
             _self._updateThumbnailWidth();
         }
 
-        // On viewport rotation, only refresh the CURRENT (main) image's
-        // thumbnail — refreshing every thumbnail would hammer the IIIF server
-        // and is rarely what the user actually wants. Thumbnails for other
-        // z-planes keep whatever rotation they were last fetched at; users can
-        // refresh them individually by clicking on them (which makes them the
-        // new main image), or in bulk via the "Update all thumbnails" button.
+        // CSS rotation is free, so refresh every thumbnail on viewport rotate.
         var osdViewer = _self.parent.parent && _self.parent.parent.viewer
             ? _self.parent.parent.viewer.osd
             : null;
         if (osdViewer) {
             osdViewer.addHandler('rotate', function () {
-                _self._updateMainImageThumbnail();
+                _self._updateAllThumbnails();
+                // previous: only the main image refreshed (kept fetch cost low)
+                // _self._updateMainImageThumbnail();
             });
         }
 
@@ -460,7 +457,11 @@ function ZPlaneList(parent) {
     };
 
     /**
-     * Given an index, will return the appropriate thumbnail image
+     * Given an index, will return the appropriate thumbnail image.
+     * The URL is rotation-independent: the same un-rotated IIIF image serves
+     * every rotation, and the actual rotation is applied client-side via CSS
+     * transform on the <img>. This keeps the browser image cache warm across
+     * rotations and removes the round-trip on rotate events.
      * TODO should be moved to somewhere more appropriate
      */
     this._getThumbnailURL = function (index) {
@@ -470,30 +471,36 @@ function ZPlaneList(parent) {
 
         var firstURL = _self.collection[index].info[0].url;
         var height = _self._thumbnailProperties.height;
-        // Each collection item carries its own thumbnailRotation (set when the
-        // item was added or last refreshed). Thumbnails for other z-planes keep
-        // their old rotation until explicitly refreshed.
-        var rotation = (typeof _self.collection[index].thumbnailRotation === 'number')
-            ? _self.collection[index].thumbnailRotation
-            : _self._getCurrentRotation();
-        var width = _self._getThumbnailWidthForRotation(rotation);
+        var nativeWidth = _self._getThumbnailWidthForRotation(0);
 
         // if iiif, use the api to get it
         // NOTE this is hacky and should be documented as an assumption
         // we're assuming that we can use the same iiif server as info.json location
         // and we're ignoring the @id attribute inside the info.json
         if (firstURL.indexOf("info.json") !== -1) {
-            // IIIF size is applied BEFORE rotation, so a 90°/270° rotation
-            // transposes the output. To get an output of `width × height` after
-            // rotation, ask the server for `height,width` at 90°/270° (and
-            // `width,height` at 0°/180°).
-            var urlW = (rotation === 90 || rotation === 270) ? height : width;
-            var urlH = (rotation === 90 || rotation === 270) ? width  : height;
-            return firstURL.replace("/info.json", "") + "/full/" + urlW + "," + urlH + "/" + rotation + "/default.jpg";
+            return firstURL.replace("/info.json", "") + "/full/" + nativeWidth + "," + height + "/0/default.jpg";
         }
 
         // use the default
         return "./images/placeholder.png";
+    }
+
+    /**
+     * CSS transform string that produces the rotated thumbnail visual from
+     * the un-rotated <img>. For 90°/270° we also need to scale (height stays
+     * fixed across rotations, so the rotated image is scaled down by 1/aspect).
+     */
+    this._getThumbnailTransform = function (rotation) {
+        if (rotation === 0) return '';
+        if (rotation === 180) return 'rotate(180deg)';
+        // 90°/270°: rotate then scale so the visual fits the thumbnail row
+        // height. If main image dimensions aren't known yet, skip the scale —
+        // the thumbnail will look slightly off until init completes.
+        if (!_self._mainImageWidth || !_self._mainImageHeight) {
+            return 'rotate(' + rotation + 'deg)';
+        }
+        var aspect = _self._mainImageWidth / _self._mainImageHeight;
+        return 'rotate(' + rotation + 'deg) scale(' + (1 / aspect) + ')';
     }
 
     /**
@@ -541,17 +548,19 @@ function ZPlaneList(parent) {
      */
     this._refreshSingleThumbnailDOM = function (index) {
         if (index < 0 || index >= _self.collection.length) return;
-        var newURL = _self._getThumbnailURL(index);
         var rotation = (typeof _self.collection[index].thumbnailRotation === 'number')
             ? _self.collection[index].thumbnailRotation
             : _self._getCurrentRotation();
-        var newWidth = _self._getThumbnailWidthForRotation(rotation);
-        var imgs = _self._zPlaneContainer
-            ? _self._zPlaneContainer.querySelectorAll('.z-plane-image')
-            : document.querySelectorAll('.z-plane-image');
+        var wrapperWidth = _self._getThumbnailWidthForRotation(rotation);
+        var transform = _self._getThumbnailTransform(rotation);
+        var container = _self._zPlaneContainer || document;
+        var wrappers = container.querySelectorAll('.z-plane-thumb-wrapper');
+        var imgs = container.querySelectorAll('.z-plane-image');
+        if (wrappers[index]) {
+            wrappers[index].style.width = wrapperWidth + 'px';
+        }
         if (imgs[index]) {
-            imgs[index].src = newURL;
-            imgs[index].style.width = newWidth + 'px';
+            imgs[index].style.transform = transform;
         }
     }
 
@@ -658,22 +667,34 @@ function ZPlaneList(parent) {
 
             var carousel = '';
 
+            var nativeWidth = _self._getThumbnailWidthForRotation(0);
+            var thumbHeight = _self._thumbnailProperties.height;
+            var maxWidth = _self._thumbnailProperties.maxWidth;
+
             for (var i = 0; i < Math.min(_self.pageSize, _self.collection.length); i++) {
-                // Width is per-item now: different thumbnails can be at
-                // different rotations, and their aspect ratios (and therefore
-                // widths) differ. Height stays fixed across the row.
+                // Per-item rotation drives the wrapper width and the inner
+                // <img>'s CSS transform. The <img> itself is always at the
+                // un-rotated native size; the wrapper is the rotated AABB.
                 var itemRotation = (typeof _self.collection[i].thumbnailRotation === 'number')
                     ? _self.collection[i].thumbnailRotation
                     : _self._getCurrentRotation();
-                var itemWidth = _self._getThumbnailWidthForRotation(itemRotation);
+                var wrapperWidth = _self._getThumbnailWidthForRotation(itemRotation);
+                var transform = _self._getThumbnailTransform(itemRotation);
+                var wrapperStyles = [
+                    "width:" + wrapperWidth + "px",
+                    "height:" + thumbHeight + "px",
+                    "max-width:" + maxWidth + "px"
+                ];
                 var imgStyles = [
-                    "width:" + itemWidth + "px",
-                    "height:" + _self._thumbnailProperties.height + "px",
-                    "max-width:" + _self._thumbnailProperties.maxWidth + "px"
+                    "width:" + nativeWidth + "px",
+                    "height:" + thumbHeight + "px",
+                    "transform:" + transform
                 ];
                 carousel += '' +
                     '<div class="z-plane" data-collection-index="' + i + '" data-z-index="' + _self.collection[i].zIndex + '">' +
-                        '<img src="' + _self._getThumbnailURL(i) + '" style="' + imgStyles.join(";") + '" class="z-plane-image">' +
+                        '<div class="z-plane-thumb-wrapper" style="' + wrapperStyles.join(";") + '">' +
+                            '<img src="' + _self._getThumbnailURL(i) + '" style="' + imgStyles.join(";") + '" class="z-plane-image">' +
+                        '</div>' +
                         '<div class="z-plane-id">' +
                             (_self.collection[i].zIndex).toString() +
                         '</div>' +
@@ -700,14 +721,6 @@ function ZPlaneList(parent) {
         var jumpButtom = '<button id="z-index-jump-button" class="info-buttom-container" data-tippy-placement="top" data-tippy-content="Jump to the given Z index">' +
                             '<i class="glyphicon glyphicon-share-alt jump-to-button"></i>' +
                         '</button>';
-        // Manual "refresh every thumbnail to the current viewport rotation"
-        // button. Sits to the left of the Z-index input so it's discoverable
-        // alongside the other z-plane controls. Temporary — added so we can
-        // discuss the refresh model before deciding on the final UX.
-        var updateAllThumbnailsButton =
-            '<button id="update-all-thumbnails" class="info-buttom-container btn update-thumbnails-btn" data-tippy-placement="top" data-tippy-content="Update all thumbnails to the current rotation">' +
-                '<i class="fas fa-sync update-all-thumbnails-button"></i>' +
-            '</button>';
         var updateButton = '';
 
         if (_self.canUpdateDefaultZIndex == true) {
@@ -717,7 +730,6 @@ function ZPlaneList(parent) {
                             '</button>';
         }
         zPlaneInfo.innerHTML = '' +
-            updateAllThumbnailsButton +
             'Z index: <input id="main-image-z-index" onkeypress="return (event.charCode == 8 || event.charCode == 0 || event.charCode == 13) ? null : event.charCode >= 48 && event.charCode <= 57" class="main-image-z-index" value="' + _self.mainImageZIndex + '" placeholder="' + _self.mainImageZIndex + '">' +
             '<span>' +
                 jumpButtom +
@@ -726,11 +738,6 @@ function ZPlaneList(parent) {
             '<span>(' + _self.totalCount + ' generated, default Z=<span id="current-default-z-index">' + _self.defaultZIndex + '</span>)</span>';
 
         _self._renderUpdateDefaultZButton();
-
-        var updateAllBtn = zPlaneInfo.querySelector('#update-all-thumbnails');
-        if (updateAllBtn) {
-            updateAllBtn.addEventListener('click', _self._updateAllThumbnails);
-        }
 
         var inputChangedPromise = null;
         var inputEl = zPlaneInfo.querySelector('#main-image-z-index');
@@ -812,8 +819,17 @@ function ZPlaneList(parent) {
                     '<div class="down-arrow" id="slider-tooltip-arrow"></div>' +
                 '</div>' +
                 '<div class="min-max">'+_self.sliderRange.max+'</div>' +
-                '<button class="circular-button" id="slider-next-button" data-tippy-placement="top" data-tippy-content="Next Z index"><i class="glyphicon glyphicon-triangle-right right"></i></button>' ;
+                '<button class="circular-button" id="slider-next-button" data-tippy-placement="top" data-tippy-content="Next Z index"><i class="glyphicon glyphicon-triangle-right right"></i></button>' +
+                '<button id="update-all-thumbnails" class="update-thumbnails-btn" data-tippy-placement="top" data-tippy-content="Update all thumbnails to the current rotation">' +
+                    '<i class="fas fa-sync update-all-thumbnails-button"></i>' +
+                    '<span>Update Thumbnails</span>' +
+                '</button>';
         zPlaneSlider.innerHTML = slider;
+
+        var updateAllBtn = zPlaneSlider.querySelector('#update-all-thumbnails');
+        if (updateAllBtn) {
+            updateAllBtn.addEventListener('click', _self._updateAllThumbnails);
+        }
 
         var slider = zPlaneSlider.querySelector('#z-index-slider');
         if (slider) {

--- a/js/toolbar/z-plane-list.js
+++ b/js/toolbar/z-plane-list.js
@@ -127,9 +127,28 @@ function ZPlaneList(parent) {
      */
     this.init = function (data) {
 
-        // change the width to be based on the image
+        // Cache the main image dimensions so we can recompute the thumbnail
+        // width when the viewport rotation changes (the rotated image's
+        // aspect ratio is the inverse of the original).
         if (data.mainImageWidth > 0 & data.mainImageHeight > 0) {
-            _self._thumbnailProperties.width = Math.ceil(_self._thumbnailProperties.height * (data.mainImageWidth / data.mainImageHeight));
+            _self._mainImageWidth = data.mainImageWidth;
+            _self._mainImageHeight = data.mainImageHeight;
+            _self._updateThumbnailWidth();
+        }
+
+        // On viewport rotation, only refresh the CURRENT (main) image's
+        // thumbnail — refreshing every thumbnail would hammer the IIIF server
+        // and is rarely what the user actually wants. Thumbnails for other
+        // z-planes keep whatever rotation they were last fetched at; users can
+        // refresh them individually by clicking on them (which makes them the
+        // new main image), or in bulk via the "Update all thumbnails" button.
+        var osdViewer = _self.parent.parent && _self.parent.parent.viewer
+            ? _self.parent.parent.viewer.osd
+            : null;
+        if (osdViewer) {
+            osdViewer.addHandler('rotate', function () {
+                _self._updateMainImageThumbnail();
+            });
         }
 
         _self._currentRequestID = -1;
@@ -209,6 +228,15 @@ function ZPlaneList(parent) {
             return;
 
         console.log("updating the z-plane-list with the following data:", data, data.images.length);
+
+        // Stamp each new item with the current viewport rotation. A new page
+        // is "totally new" so it's fine to fetch every thumbnail at the
+        // current rotation here — different from the rotate-event path where
+        // only the main image refreshes.
+        var stampRotation = _self._getCurrentRotation();
+        for (var idx = 0; idx < data.images.length; idx++) {
+            data.images[idx].thumbnailRotation = stampRotation;
+        }
 
         if (_self.appendData == false) {
             this.collection = data.images;
@@ -441,20 +469,122 @@ function ZPlaneList(parent) {
         }
 
         var firstURL = _self.collection[index].info[0].url;
-
-        var width = _self._thumbnailProperties.width,
-            height = _self._thumbnailProperties.height;
+        var height = _self._thumbnailProperties.height;
+        // Each collection item carries its own thumbnailRotation (set when the
+        // item was added or last refreshed). Thumbnails for other z-planes keep
+        // their old rotation until explicitly refreshed.
+        var rotation = (typeof _self.collection[index].thumbnailRotation === 'number')
+            ? _self.collection[index].thumbnailRotation
+            : _self._getCurrentRotation();
+        var width = _self._getThumbnailWidthForRotation(rotation);
 
         // if iiif, use the api to get it
         // NOTE this is hacky and should be documented as an assumption
         // we're assuming that we can use the same iiif server as info.json location
         // and we're ignoring the @id attribute inside the info.json
         if (firstURL.indexOf("info.json") !== -1) {
-            return firstURL.replace("/info.json", "") + "/full/" + width + "," + height + "/0/default.jpg";
+            // IIIF size is applied BEFORE rotation, so a 90°/270° rotation
+            // transposes the output. To get an output of `width × height` after
+            // rotation, ask the server for `height,width` at 90°/270° (and
+            // `width,height` at 0°/180°).
+            var urlW = (rotation === 90 || rotation === 270) ? height : width;
+            var urlH = (rotation === 90 || rotation === 270) ? width  : height;
+            return firstURL.replace("/info.json", "") + "/full/" + urlW + "," + urlH + "/" + rotation + "/default.jpg";
         }
 
         // use the default
         return "./images/placeholder.png";
+    }
+
+    /**
+     * Reads the current viewport rotation in degrees from the OSD viewer.
+     * Returns 0 if the viewer isn't accessible yet (during early init).
+     */
+    this._getCurrentRotation = function () {
+        try {
+            return _self.parent.parent.viewer.osd.viewport.getRotation();
+        } catch (e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Returns the thumbnail width (in CSS pixels) for a given rotation. At
+     * 90°/270° the rotated image's aspect ratio is the inverse of the
+     * original, so the width is recomputed accordingly. Height stays fixed
+     * at `_thumbnailProperties.height` for all rotations to keep the row
+     * height consistent across mixed-rotation thumbnails.
+     */
+    this._getThumbnailWidthForRotation = function (rotation) {
+        if (!_self._mainImageWidth || !_self._mainImageHeight) {
+            return _self._thumbnailProperties.width;
+        }
+        var ratio = (rotation === 90 || rotation === 270)
+            ? (_self._mainImageHeight / _self._mainImageWidth)
+            : (_self._mainImageWidth / _self._mainImageHeight);
+        return Math.ceil(_self._thumbnailProperties.height * ratio);
+    }
+
+    /**
+     * Recomputes `_thumbnailProperties.width` based on the current viewport
+     * rotation. Used as a layout estimate for page-size calculations and for
+     * the default width of any thumbnails whose rotation isn't yet known.
+     */
+    this._updateThumbnailWidth = function () {
+        _self._thumbnailProperties.width = _self._getThumbnailWidthForRotation(_self._getCurrentRotation());
+    }
+
+    /**
+     * Updates a single thumbnail's DOM in-place — src + width — to reflect
+     * the rotation that's now recorded on `collection[index].thumbnailRotation`.
+     * Doesn't re-render the rest of the carousel.
+     */
+    this._refreshSingleThumbnailDOM = function (index) {
+        if (index < 0 || index >= _self.collection.length) return;
+        var newURL = _self._getThumbnailURL(index);
+        var rotation = (typeof _self.collection[index].thumbnailRotation === 'number')
+            ? _self.collection[index].thumbnailRotation
+            : _self._getCurrentRotation();
+        var newWidth = _self._getThumbnailWidthForRotation(rotation);
+        var imgs = _self._zPlaneContainer
+            ? _self._zPlaneContainer.querySelectorAll('.z-plane-image')
+            : document.querySelectorAll('.z-plane-image');
+        if (imgs[index]) {
+            imgs[index].src = newURL;
+            imgs[index].style.width = newWidth + 'px';
+        }
+    }
+
+    /**
+     * Finds the currently-active main image in the visible collection and
+     * refreshes only its thumbnail to the current viewport rotation. Called
+     * on every OSD rotate event.
+     */
+    this._updateMainImageThumbnail = function () {
+        var idx = -1;
+        for (var i = 0; i < _self.collection.length; i++) {
+            if (_self.collection[i].zIndex === _self.mainImageZIndex) {
+                idx = i;
+                break;
+            }
+        }
+        if (idx === -1) return; // current main not in this page
+        _self.collection[idx].thumbnailRotation = _self._getCurrentRotation();
+        _self._refreshSingleThumbnailDOM(idx);
+    }
+
+    /**
+     * Sets every thumbnail in the current collection to the current viewport
+     * rotation, then re-renders the carousel. Wired up to the "Update all
+     * thumbnails" toolbar button.
+     */
+    this._updateAllThumbnails = function () {
+        var rotation = _self._getCurrentRotation();
+        for (var i = 0; i < _self.collection.length; i++) {
+            _self.collection[i].thumbnailRotation = rotation;
+        }
+        _self._updateThumbnailWidth();
+        _self._renderZPlaneCarousel();
     }
 
     /**
@@ -481,6 +611,12 @@ function ZPlaneList(parent) {
             _self._renderZPlaneInfo();
             _self._renderActiveZPlane();
             _self._renderZPlaneSlider();
+
+            // The newly-selected image becomes the main image and inherits the
+            // current viewport rotation. Refresh its thumbnail so what the
+            // user sees in the carousel matches what's now on screen.
+            _self.collection[index].thumbnailRotation = _self._getCurrentRotation();
+            _self._refreshSingleThumbnailDOM(index);
 
             _self.parent.dispatchEvent('updateMainImage', _self.collection[index]);
         }
@@ -520,14 +656,21 @@ function ZPlaneList(parent) {
                 zPlaneContainer.style.justifyContent = 'center';
             }
 
-            var carousel = '',
-                imgStyles = [
-                    "width:" + _self._thumbnailProperties.width + "px",
-                    "height:" + _self._thumbnailProperties.height + "px",
-                    "max-width:" + _self._thumbnailProperties.maxWidth + "px"
-                ]
+            var carousel = '';
 
             for (var i = 0; i < Math.min(_self.pageSize, _self.collection.length); i++) {
+                // Width is per-item now: different thumbnails can be at
+                // different rotations, and their aspect ratios (and therefore
+                // widths) differ. Height stays fixed across the row.
+                var itemRotation = (typeof _self.collection[i].thumbnailRotation === 'number')
+                    ? _self.collection[i].thumbnailRotation
+                    : _self._getCurrentRotation();
+                var itemWidth = _self._getThumbnailWidthForRotation(itemRotation);
+                var imgStyles = [
+                    "width:" + itemWidth + "px",
+                    "height:" + _self._thumbnailProperties.height + "px",
+                    "max-width:" + _self._thumbnailProperties.maxWidth + "px"
+                ];
                 carousel += '' +
                     '<div class="z-plane" data-collection-index="' + i + '" data-z-index="' + _self.collection[i].zIndex + '">' +
                         '<img src="' + _self._getThumbnailURL(i) + '" style="' + imgStyles.join(";") + '" class="z-plane-image">' +
@@ -557,6 +700,14 @@ function ZPlaneList(parent) {
         var jumpButtom = '<button id="z-index-jump-button" class="info-buttom-container" data-tippy-placement="top" data-tippy-content="Jump to the given Z index">' +
                             '<i class="glyphicon glyphicon-share-alt jump-to-button"></i>' +
                         '</button>';
+        // Manual "refresh every thumbnail to the current viewport rotation"
+        // button. Sits to the left of the Z-index input so it's discoverable
+        // alongside the other z-plane controls. Temporary — added so we can
+        // discuss the refresh model before deciding on the final UX.
+        var updateAllThumbnailsButton =
+            '<button id="update-all-thumbnails" class="info-buttom-container btn update-thumbnails-btn" data-tippy-placement="top" data-tippy-content="Update all thumbnails to the current rotation">' +
+                '<i class="fas fa-sync update-all-thumbnails-button"></i>' +
+            '</button>';
         var updateButton = '';
 
         if (_self.canUpdateDefaultZIndex == true) {
@@ -566,6 +717,7 @@ function ZPlaneList(parent) {
                             '</button>';
         }
         zPlaneInfo.innerHTML = '' +
+            updateAllThumbnailsButton +
             'Z index: <input id="main-image-z-index" onkeypress="return (event.charCode == 8 || event.charCode == 0 || event.charCode == 13) ? null : event.charCode >= 48 && event.charCode <= 57" class="main-image-z-index" value="' + _self.mainImageZIndex + '" placeholder="' + _self.mainImageZIndex + '">' +
             '<span>' +
                 jumpButtom +
@@ -574,6 +726,11 @@ function ZPlaneList(parent) {
             '<span>(' + _self.totalCount + ' generated, default Z=<span id="current-default-z-index">' + _self.defaultZIndex + '</span>)</span>';
 
         _self._renderUpdateDefaultZButton();
+
+        var updateAllBtn = zPlaneInfo.querySelector('#update-all-thumbnails');
+        if (updateAllBtn) {
+            updateAllBtn.addEventListener('click', _self._updateAllThumbnails);
+        }
 
         var inputChangedPromise = null;
         var inputEl = zPlaneInfo.querySelector('#main-image-z-index');

--- a/js/toolbar/z-plane-list.js
+++ b/js/toolbar/z-plane-list.js
@@ -476,21 +476,39 @@ function ZPlaneList(parent) {
     }
 
     /**
-     * CSS transform string that produces the rotated thumbnail visual from
-     * the un-rotated <img>. For 90°/270° we also need to scale (height stays
-     * fixed across rotations, so the rotated image is scaled down by 1/aspect).
+     * Geometry for a thumbnail at an arbitrary rotation. The <img> is rendered
+     * un-rotated at native size (thumbH tall), then CSS-transformed about its
+     * center. The carousel row height is fixed at thumbH, so we scale the
+     * rotated image so its axis-aligned bounding box is thumbH tall; the
+     * wrapper takes that box's width. Right angles fall out of this exactly
+     * (e.g. 90°/270° give width = thumbH / aspect, scale = 1 / aspect).
+     * @param {number} rotation degrees (any value, not just multiples of 90)
+     * @returns {{width:number, scale:number}}
+     */
+    this._getThumbnailRotationGeometry = function (rotation) {
+        if (!_self._mainImageWidth || !_self._mainImageHeight) {
+            return { width: _self._thumbnailProperties.width, scale: 1 };
+        }
+        var thumbH = _self._thumbnailProperties.height;
+        var nativeW = thumbH * (_self._mainImageWidth / _self._mainImageHeight);
+        var rad = rotation * Math.PI / 180;
+        // clamp FP noise (cos(90°) is ~6e-17, not 0) so right angles stay exact
+        var cos = Math.abs(Math.cos(rad)); if (cos < 1e-9) cos = 0;
+        var sin = Math.abs(Math.sin(rad)); if (sin < 1e-9) sin = 0;
+        // axis-aligned bounding box of the rotated native image
+        var bboxW = nativeW * cos + thumbH * sin;
+        var bboxH = nativeW * sin + thumbH * cos;
+        var scale = thumbH / bboxH; // bring the rotated height back to thumbH
+        return { width: Math.ceil(bboxW * scale), scale: scale };
+    }
+
+    /**
+     * CSS transform that rotates the native <img> and scales it so the rotated
+     * image's bounding box fits the fixed thumbnail row height.
      */
     this._getThumbnailTransform = function (rotation) {
         if (rotation === 0) return '';
-        if (rotation === 180) return 'rotate(180deg)';
-        // 90°/270°: rotate then scale so the visual fits the thumbnail row
-        // height. If main image dimensions aren't known yet, skip the scale —
-        // the thumbnail will look slightly off until init completes.
-        if (!_self._mainImageWidth || !_self._mainImageHeight) {
-            return 'rotate(' + rotation + 'deg)';
-        }
-        var aspect = _self._mainImageWidth / _self._mainImageHeight;
-        return 'rotate(' + rotation + 'deg) scale(' + (1 / aspect) + ')';
+        return 'rotate(' + rotation + 'deg) scale(' + _self._getThumbnailRotationGeometry(rotation).scale + ')';
     }
 
     /**
@@ -506,20 +524,12 @@ function ZPlaneList(parent) {
     }
 
     /**
-     * Returns the thumbnail width (in CSS pixels) for a given rotation. At
-     * 90°/270° the rotated image's aspect ratio is the inverse of the
-     * original, so the width is recomputed accordingly. Height stays fixed
-     * at `_thumbnailProperties.height` for all rotations to keep the row
-     * height consistent across mixed-rotation thumbnails.
+     * Thumbnail wrapper width (CSS px) for a given rotation. Height stays fixed
+     * at `_thumbnailProperties.height` so the carousel row height is consistent
+     * across mixed-rotation thumbnails.
      */
     this._getThumbnailWidthForRotation = function (rotation) {
-        if (!_self._mainImageWidth || !_self._mainImageHeight) {
-            return _self._thumbnailProperties.width;
-        }
-        var ratio = (rotation === 90 || rotation === 270)
-            ? (_self._mainImageHeight / _self._mainImageWidth)
-            : (_self._mainImageWidth / _self._mainImageHeight);
-        return Math.ceil(_self._thumbnailProperties.height * ratio);
+        return _self._getThumbnailRotationGeometry(rotation).width;
     }
 
     /**

--- a/js/toolbar/z-plane-list.js
+++ b/js/toolbar/z-plane-list.js
@@ -136,15 +136,14 @@ function ZPlaneList(parent) {
             _self._updateThumbnailWidth();
         }
 
-        // CSS rotation is free, so refresh every thumbnail on viewport rotate.
+        // CSS rotation is free, so re-render every thumbnail on viewport rotate.
         var osdViewer = _self.parent.parent && _self.parent.parent.viewer
             ? _self.parent.parent.viewer.osd
             : null;
         if (osdViewer) {
             osdViewer.addHandler('rotate', function () {
-                _self._updateAllThumbnails();
-                // previous: only the main image refreshed (kept fetch cost low)
-                // _self._updateMainImageThumbnail();
+                _self._updateThumbnailWidth();
+                _self._renderZPlaneCarousel();
             });
         }
 
@@ -225,15 +224,6 @@ function ZPlaneList(parent) {
             return;
 
         console.log("updating the z-plane-list with the following data:", data, data.images.length);
-
-        // Stamp each new item with the current viewport rotation. A new page
-        // is "totally new" so it's fine to fetch every thumbnail at the
-        // current rotation here — different from the rotate-event path where
-        // only the main image refreshes.
-        var stampRotation = _self._getCurrentRotation();
-        for (var idx = 0; idx < data.images.length; idx++) {
-            data.images[idx].thumbnailRotation = stampRotation;
-        }
 
         if (_self.appendData == false) {
             this.collection = data.images;
@@ -542,61 +532,6 @@ function ZPlaneList(parent) {
     }
 
     /**
-     * Updates a single thumbnail's DOM in-place — src + width — to reflect
-     * the rotation that's now recorded on `collection[index].thumbnailRotation`.
-     * Doesn't re-render the rest of the carousel.
-     */
-    this._refreshSingleThumbnailDOM = function (index) {
-        if (index < 0 || index >= _self.collection.length) return;
-        var rotation = (typeof _self.collection[index].thumbnailRotation === 'number')
-            ? _self.collection[index].thumbnailRotation
-            : _self._getCurrentRotation();
-        var wrapperWidth = _self._getThumbnailWidthForRotation(rotation);
-        var transform = _self._getThumbnailTransform(rotation);
-        var container = _self._zPlaneContainer || document;
-        var wrappers = container.querySelectorAll('.z-plane-thumb-wrapper');
-        var imgs = container.querySelectorAll('.z-plane-image');
-        if (wrappers[index]) {
-            wrappers[index].style.width = wrapperWidth + 'px';
-        }
-        if (imgs[index]) {
-            imgs[index].style.transform = transform;
-        }
-    }
-
-    /**
-     * Finds the currently-active main image in the visible collection and
-     * refreshes only its thumbnail to the current viewport rotation. Called
-     * on every OSD rotate event.
-     */
-    this._updateMainImageThumbnail = function () {
-        var idx = -1;
-        for (var i = 0; i < _self.collection.length; i++) {
-            if (_self.collection[i].zIndex === _self.mainImageZIndex) {
-                idx = i;
-                break;
-            }
-        }
-        if (idx === -1) return; // current main not in this page
-        _self.collection[idx].thumbnailRotation = _self._getCurrentRotation();
-        _self._refreshSingleThumbnailDOM(idx);
-    }
-
-    /**
-     * Sets every thumbnail in the current collection to the current viewport
-     * rotation, then re-renders the carousel. Wired up to the "Update all
-     * thumbnails" toolbar button.
-     */
-    this._updateAllThumbnails = function () {
-        var rotation = _self._getCurrentRotation();
-        for (var i = 0; i < _self.collection.length; i++) {
-            _self.collection[i].thumbnailRotation = rotation;
-        }
-        _self._updateThumbnailWidth();
-        _self._renderZPlaneCarousel();
-    }
-
-    /**
      * This function sends a request to chaise to update the default z index, and shows a spinner in place of the save icon
      */
     this._saveDefaultZIndexHandler = function () {
@@ -620,12 +555,6 @@ function ZPlaneList(parent) {
             _self._renderZPlaneInfo();
             _self._renderActiveZPlane();
             _self._renderZPlaneSlider();
-
-            // The newly-selected image becomes the main image and inherits the
-            // current viewport rotation. Refresh its thumbnail so what the
-            // user sees in the carousel matches what's now on screen.
-            _self.collection[index].thumbnailRotation = _self._getCurrentRotation();
-            _self._refreshSingleThumbnailDOM(index);
 
             _self.parent.dispatchEvent('updateMainImage', _self.collection[index]);
         }
@@ -671,15 +600,14 @@ function ZPlaneList(parent) {
             var thumbHeight = _self._thumbnailProperties.height;
             var maxWidth = _self._thumbnailProperties.maxWidth;
 
+            // Every thumbnail tracks the current viewport rotation. The <img>
+            // is always at the un-rotated native size; the wrapper is the
+            // rotated AABB and the inner <img> gets the CSS transform.
+            var rotation = _self._getCurrentRotation();
+            var wrapperWidth = _self._getThumbnailWidthForRotation(rotation);
+            var transform = _self._getThumbnailTransform(rotation);
+
             for (var i = 0; i < Math.min(_self.pageSize, _self.collection.length); i++) {
-                // Per-item rotation drives the wrapper width and the inner
-                // <img>'s CSS transform. The <img> itself is always at the
-                // un-rotated native size; the wrapper is the rotated AABB.
-                var itemRotation = (typeof _self.collection[i].thumbnailRotation === 'number')
-                    ? _self.collection[i].thumbnailRotation
-                    : _self._getCurrentRotation();
-                var wrapperWidth = _self._getThumbnailWidthForRotation(itemRotation);
-                var transform = _self._getThumbnailTransform(itemRotation);
                 var wrapperStyles = [
                     "width:" + wrapperWidth + "px",
                     "height:" + thumbHeight + "px",
@@ -819,17 +747,8 @@ function ZPlaneList(parent) {
                     '<div class="down-arrow" id="slider-tooltip-arrow"></div>' +
                 '</div>' +
                 '<div class="min-max">'+_self.sliderRange.max+'</div>' +
-                '<button class="circular-button" id="slider-next-button" data-tippy-placement="top" data-tippy-content="Next Z index"><i class="glyphicon glyphicon-triangle-right right"></i></button>' +
-                '<button id="update-all-thumbnails" class="update-thumbnails-btn" data-tippy-placement="top" data-tippy-content="Update all thumbnails to the current rotation">' +
-                    '<i class="fas fa-sync update-all-thumbnails-button"></i>' +
-                    '<span>Update Thumbnails</span>' +
-                '</button>';
+                '<button class="circular-button" id="slider-next-button" data-tippy-placement="top" data-tippy-content="Next Z index"><i class="glyphicon glyphicon-triangle-right right"></i></button>';
         zPlaneSlider.innerHTML = slider;
-
-        var updateAllBtn = zPlaneSlider.querySelector('#update-all-thumbnails');
-        if (updateAllBtn) {
-            updateAllBtn.addEventListener('click', _self._updateAllThumbnails);
-        }
 
         var slider = zPlaneSlider.querySelector('#z-index-slider');
         if (slider) {

--- a/js/viewer/annotation/annotation-utils.js
+++ b/js/viewer/annotation/annotation-utils.js
@@ -25,20 +25,23 @@ AnnotationUtils.prototype.styleObjectToString = function (styleObject) {
  * @return {object} the returned object is a key (eg style property like 'font-size') and value (eg '20px') pair
  */
 AnnotationUtils.prototype.styleStringToObject = function (styleString) {
-	styleString = styleString || '';
-	styleString = styleString.replace(/\s/g, '');
-	if (styleString[styleString.length - 1] == ';') {
-		styleString = styleString.slice(0, styleString.length - 1);
+	// Trim only the outer string and split into declarations; whitespace *within*
+	// a value (e.g. `transform-origin: 0px 0px`) must be preserved or the browser
+	// rejects the value and falls back to the default.
+	styleString = (styleString || '').trim();
+	if (styleString.endsWith(';')) {
+		styleString = styleString.slice(0, -1);
 	}
 
 	var styleObject = {};
+	var declarations = styleString.split(';');
 
-	styleString = styleString.split(';');
-
-	for (i = 0; i < styleString.length; i++) {
-		var property, value;
-		[property, value] = styleString[i].split(':')
-		if (value) {
+	for (var i = 0; i < declarations.length; i++) {
+		var idx = declarations[i].indexOf(':');
+		if (idx === -1) continue;
+		var property = declarations[i].slice(0, idx).trim();
+		var value = declarations[i].slice(idx + 1).trim();
+		if (property && value) {
 			styleObject[property] = value;
 		}
 	}

--- a/js/viewer/annotation/text.js
+++ b/js/viewer/annotation/text.js
@@ -358,7 +358,7 @@ Text.prototype.addTextBox = function (groupId, importedObj) {
     var textInput = document.createElementNS("http://www.w3.org/1999/xhtml", "div");
     this.setForeignObj(svgForeignObj);
 
-    fontSize = document.querySelector(".fontInput").value;
+    var fontSize = document.querySelector(".fontInput").value;
     this.changeFontSize(fontSize);
 
     // Set the attributes of the foreign object, div and textarea
@@ -507,7 +507,7 @@ Text.prototype.changeFontSize = function (fontSize) {
  */
 Text.prototype.initDragElement = function () {
 
-    pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
+    var pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
 
     var foreignObj = this.getForeignObj();
     var divCont = foreignObj.childNodes[0];
@@ -592,7 +592,7 @@ Text.prototype.initResizeElement = function () {
     var startX, startY, startWidth, startHeight;
 
     // Create the resize element for the text input
-    bottomright = document.createElement("div");
+    var bottomright = document.createElement("div");
     bottomright.className = "text-foreign-object-resizer-right";
     divCont.appendChild(bottomright);
 
@@ -608,7 +608,7 @@ Text.prototype.initResizeElement = function () {
     // Function to intialize the resize movement of the text input
     function initDrag(e) {
         e.stopImmediatePropagation();
-        resizer = e.target.className;
+        var resizer = e.target.className;
 
         startX = e.clientX;
         startY = e.clientY;

--- a/js/viewer/annotation/text.js
+++ b/js/viewer/annotation/text.js
@@ -46,9 +46,11 @@ Text.prototype.getForeignObj = function() {
 }
 
 Text.prototype.renderSVG = function () {
-    // We do not need to render the text tag for the text annotation
-    // since we are using the foreign object to render the text input
-    // and the transformed text p tag
+    /**
+     * We do not need to render the text tag for the text annotation
+     * since we are using the foreign object to render the text input
+     * and the transformed text p tag
+     */
     return;
 }
 
@@ -77,11 +79,12 @@ Text.prototype.positionAnnotation = function (point) {
 Text.prototype.transform = function () {
 
     var foreignObj = this.getForeignObj();
-    // Locate the wrapper and the input by class rather than child index. With
-    // nested contenteditable elements, browsers insert placeholder text / <br>
-    // nodes during focus that shift childNodes[0] away from the expected
-    // element — which previously made hasValue false and silently deleted the
-    // user's text on finalize.
+    /**
+     * Locate the wrapper and input by class rather than child index: nested
+     * contenteditable elements get browser-injected placeholder/<br> nodes on
+     * focus that shift childNodes[0], which previously made hasValue false and
+     * silently deleted the user's text on finalize.
+     */
     var div = foreignObj.querySelector(".text-foreign-object-div");
     var textInput = foreignObj.querySelector(".text-foreign-object-input");
     const hasValue = textInput && textInput.innerText && textInput.innerText.trim() != "";
@@ -90,7 +93,6 @@ Text.prototype.transform = function () {
     if (!hasValue) {
         foreignObj.parentNode.removeChild(foreignObj);
     }
-    // Transform only if the input is not empty
     else {
         var pText = this.createPTag(textInput, true);
 
@@ -98,8 +100,7 @@ Text.prototype.transform = function () {
         var w = div.style.marginLeft;
 
         var divPadding = window.getComputedStyle(div, null).getPropertyValue('padding');
-        // We obtain the padding and border of the div element to position the p tag correctly
-        // Both properties have been defined in pixels while creating the textarea
+        // padding and border (defined in px when the input was created) position the p tag correctly
         divPadding = parseInt(divPadding.slice(0, divPadding.length - 2)) || 0;
         var divBorder = window.getComputedStyle(div, null).getPropertyValue('border').split(" ")[0];
         divBorder = parseInt(divBorder.slice(0, divBorder.length - 2)) || 0;
@@ -113,11 +114,8 @@ Text.prototype.transform = function () {
         } else {
             w = 0;
         }
-        /* We calculate the new position x and y of the transformed text p tag by taking into
-        * consideration the padding and border of the div element and the width and height of the textarea.
-        * The code calculates the new position of text in a draggable div after transformation by considering previous width,
-        * padding, and border attributes. This is necessary because the position before transformation differs from the actual
-        * placement after transformation.
+        /* Recompute the p tag's x/y, accounting for the div's previous width, padding,
+        * and border — placement before the transform differs from the actual placement after.
         */
         foreignObj.setAttribute("x",  w + divPadding + divBorder);
         foreignObj.setAttribute("y", h + divPadding + divBorder);
@@ -125,12 +123,12 @@ Text.prototype.transform = function () {
         foreignObj.innerHTML = "";
         foreignObj.appendChild(pText);
 
-        // Size the foreignObject to fit pText exactly. We measure pText after
-        // it's in the DOM (so layout reflects the real <p>, not the contenteditable
-        // <div> it replaced) and use offsetWidth/Height because they ignore CSS
-        // transforms — getBoundingClientRect would return a rotated AABB at
-        // non-zero viewport rotation. offsetWidth/Height are integer-rounded
-        // (floor), so +1 covers the sub-pixel rounding.
+        /**
+         * Size the foreignObject to fit pText exactly, measuring after it's in the DOM
+         * (so layout reflects the real <p>). offsetWidth/Height ignore CSS transforms —
+         * getBoundingClientRect would return a rotated AABB at non-zero viewport rotation.
+         * They floor to integers, so +1 covers the sub-pixel rounding.
+         */
         pText.style.width = "max-content";
         pText.style.height = "auto";
         foreignObj.setAttribute('width', (pText.offsetWidth + 1) + 'px');
@@ -138,9 +136,11 @@ Text.prototype.transform = function () {
         pText.style.height = "fit-content";
         pText.style.width = "fit-content";
 
-        // Carry over the counter-rotation that kept the editable wrapper
-        // upright. Without this, the freshly finalized <p> would briefly show
-        // rotated until the next resizeSVG/animation event runs.
+        /**
+         * Carry over the counter-rotation that kept the editable wrapper upright.
+         * Without this, the freshly finalized <p> would briefly show rotated until
+         * the next resizeSVG/animation event runs.
+         */
         var viewerParent = this.parent.parent.parent;
         var rotation = viewerParent.osd.viewport.getRotation();
         pText.style.transformOrigin = "0 0";
@@ -160,57 +160,57 @@ Text.prototype.createPTag = function (originalObj, isTextArea) {
 
     var _self = this;
     var pText = document.createElement("p");
-    // For the live editable input field (a contenteditable <div>) read innerText
-    // to preserve plain text content and avoid pulling in any browser-injected markup.
-    // For imported/saved annotations the originalObj is already a <p>, so innerHTML
-    // is the right read.
+    /**
+     * Live editor is a contenteditable <div>: read innerText for plain text, avoiding
+     * browser-injected markup. Imported/saved annotations are already a <p>, so read innerHTML.
+     */
     var inputValue = isTextArea ? originalObj.innerText : originalObj.innerHTML;
 
-    /**
-     * make sure the content of p tag stays withing the width, the same as textarea
-     */
+    // keep the p tag content within its width, like the textarea
     pText.style.overflowWrap = "anywhere";
 
-    /**
-     * Replace all the new line characters with <br> tag to preserve the formatting
-     * this will make sure we're supporting multiple consecutive newlines
-     */
+    // pre-wrap preserves newlines (including consecutive ones) without needing <br> tags
     pText.style.whiteSpace = "pre-wrap";
 
     /**
-     * based on my testing this is not needed. also doing this throws an error in
-     * firefox when attempting to show an already saved SVG. if we decided
-     * to bring back this logic, we have to change base.js to do the following:
+     * Live editor: assign plain text via textContent. innerHTML would interpret HTML-like
+     * characters the user typed (e.g. "<img onerror=...>") as markup, corrupting the
+     * exported SVG and opening a DOM injection/XSS hole; pre-wrap still preserves newlines.
+     * Imported/saved is already real markup (<br>, etc.), so keep innerHTML.
      *
-     * foreignObj.outerHTML.replace('<br>', '<br \/>');
-     *
-     * that's because outerHTML returns <br> which is not a proper XHTML tag,
-     * so we have to replace it with the proper ones before exporting to svg.
+     * We deliberately do NOT convert "\n" to <br> (commented line below): unnecessary with
+     * pre-wrap, and it throws in firefox on re-showing a saved SVG because outerHTML emits
+     * non-XHTML "<br>" that base.js would then have to rewrite to "<br \/>" before export.
      */
     // inputValue = inputValue.replace(/\n/g, "<br \/>");
-    pText.innerHTML = inputValue;
+    if (isTextArea) {
+        pText.textContent = inputValue;
+    } else {
+        pText.innerHTML = inputValue;
+    }
 
     var styleObj = this.annotationUtils.styleStringToObject(originalObj.getAttribute("style"));
     pText.style.fontSize = styleObj["font-size"];
 
-    // if it's coming from the saved svg, just use fit-content for both width and height.
-    // the foreignObject has the proper values this will make sure the hover works properly
-    // for textarea honor the given width. and it will be adjusted later when we set the foreignObject position.
+    /**
+     * Saved svg: use fit-content for width/height (the foreignObject holds the real values,
+     * so hover works). Textarea: honor the given width; adjusted later when positioning the
+     * foreignObject.
+     */
     pText.style.height = isTextArea ? styleObj["height"] : 'fit-content';
     pText.style.width = isTextArea ? ((originalObj.clientWidth || originalObj.width) + "px") : 'fit-content';
 
     // Copy the font color of the textarea to the p tag
     pText.style.color = styleObj["color"];
 
-    // For imported (saved) text, preserve the rotation that was baked in at
-    // finalize time. transform() in this file applies `rotate(-R0)` to the
-    // <p> at finalize so subsequent viewport rotation produces a visible
-    // rotation of (R - R0) — i.e. the text is "stickied" to the image's
-    // orientation at creation time. Without copying it here, reload paths
-    // through createPTag drop the transform and the text appears un-rotated.
-    //
-    // Only the imported case needs this; transform() applies the transform
-    // itself after createPTag returns for the live finalize path.
+    /**
+     * For imported (saved) text, preserve the rotation baked in at finalize time.
+     * transform() applies `rotate(-R0)` to the <p> at finalize, so later viewport
+     * rotation shows (R - R0) — the text is "stickied" to the image's orientation at
+     * creation. Without copying it here, reload paths drop the transform and the text
+     * appears un-rotated. The live finalize path doesn't need this; transform() applies
+     * the transform itself after createPTag returns.
+     */
     if (!isTextArea) {
         if (styleObj["transform"]) {
             pText.style.transform = styleObj["transform"];
@@ -223,9 +223,11 @@ Text.prototype.createPTag = function (originalObj, isTextArea) {
     // Adding the text-hover class to the p tag for the hover effect to highlight the text
     pText.classList.add("text-hover");
 
-    // Override the default base.js event handlers for the text annotation
-    // Text annotation does not have a d3 element, so we need to add the event handlers
-    // that work without the d3 element
+    /**
+     * Override the default base.js event handlers for the text annotation.
+     * Text annotation does not have a d3 element, so we need to add the event handlers
+     * that work without the d3 element.
+     */
     _self.onClickToSelectAnnotation = function (e) {
         e.preventDefault();
         e.stopImmediatePropagation();
@@ -272,7 +274,7 @@ Text.prototype.createPTag = function (originalObj, isTextArea) {
     new OpenSeadragon.MouseTracker({
         element: pText,
         clickHandler: function (e) {
-            // intentially left empy. we just want to prevent the default behavior (zoom)
+            // intentionally left empty — just prevents the default zoom behavior
         }
     });
 
@@ -347,12 +349,12 @@ Text.prototype.addTextBox = function (groupId, importedObj) {
 
     var svgForeignObj = document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject')
     var textOuterDiv = document.createElementNS("http://www.w3.org/1999/xhtml", "div");
-    // Use a contenteditable <div> (not <textarea>) for the input field. Native
-    // form widgets like <textarea> are rendered by the browser/OS in a way
-    // that bypasses CSS transforms on ancestor SVGs, so the text content
-    // wouldn't rotate with the rest of the annotation overlay when the
-    // viewport is rotated. A plain <div> is a regular DOM node and follows
-    // the parent .annotationSVG's CSS transform correctly.
+    /**
+     * Use a contenteditable <div> (not <textarea>) for the input. Native form widgets
+     * like <textarea> bypass CSS transforms on ancestor SVGs, so the text wouldn't rotate
+     * with the annotation overlay when the viewport is rotated. A plain <div> is a regular
+     * DOM node and follows the parent .annotationSVG's CSS transform correctly.
+     */
     var textInput = document.createElementNS("http://www.w3.org/1999/xhtml", "div");
     this.setForeignObj(svgForeignObj);
 
@@ -361,12 +363,12 @@ Text.prototype.addTextBox = function (groupId, importedObj) {
 
     // Set the attributes of the foreign object, div and textarea
     textInput.setAttribute("class", "text-foreign-object-input");
-    // Only the inner input div is editable. Previously textOuterDiv and the
-    // foreignObject were also contentEditable, which meant clicks in their
-    // padding/border landed there and typed text ended up outside the styled
-    // input field (no font-size / color inherited). With only textInput
-    // contenteditable, focus always lands in the input regardless of where the
-    // user clicks within the wrapper.
+    /**
+     * Only the inner input div is editable. When textOuterDiv and the foreignObject were
+     * also contentEditable, clicks in their padding/border typed text outside the styled
+     * input (no font-size / color inherited). With only textInput editable, focus always
+     * lands in the input wherever the user clicks within the wrapper.
+     */
     textInput.setAttribute("contentEditable", "true");
     svgForeignObj.setAttribute("stroke", this._attrs["stroke"]);
     // Set the font color same as the stroke color
@@ -374,12 +376,10 @@ Text.prototype.addTextBox = function (groupId, importedObj) {
     textOuterDiv.setAttribute("width", "auto");
     textOuterDiv.setAttribute("tabindex", "-1");
     svgForeignObj.setAttribute("width", "100%");
-    // Set the height of the foreign object to be 100 times the font size
-    // This would later adjust according the font size of the text
+    // height starts at 100× the font size; adjusted later to the actual text
     svgForeignObj.setAttribute("height", this._attrs["font-size"] * 100 + "px");
     textOuterDiv.appendChild(textInput);
-    // Add the classes to the foreign object and the div for styling
-    // that handles the text wrapping and resizing and other styling
+    // classes that handle text wrapping, resizing, and other styling
     svgForeignObj.classList.add("text-foreign-object");
     textOuterDiv.classList.add("text-foreign-object-div");
 
@@ -396,12 +396,9 @@ Text.prototype.addTextBox = function (groupId, importedObj) {
     group.setAttribute("contentEditable", "true");
 
     /**
-     * Add event listeners to the textarea for input
-     * - update the the height
+     * Auto-resize the input to fit its content as the user types. The `input` event fires
+     * after the keystroke is applied (unlike `keydown`), so scrollHeight is accurate here.
      */
-    // Auto-resize the input field to fit its content as the user types.
-    // Use the `input` event (fires after the keystroke is applied, unlike
-    // `keydown` which fires before — so scrollHeight is accurate here).
     textInput.addEventListener("input", function () {
         this.style.height = "auto";
         this.style.height = this.scrollHeight + "px";
@@ -409,11 +406,10 @@ Text.prototype.addTextBox = function (groupId, importedObj) {
     });
 
     /*
-    * Safari does not support the absolute positioning property on the div inside the foregin object.
-    * If we set it to absolute, the foreign object will not be visible.
-    * Setting the absolute positioning is crucial for the positioning of the resize control on border.
-    * So, we are only setting the position absolute and adding the resize control for browsers other than Safari for now.
-    * This is a temporary fix and we need to find a better solution for this.
+    * Safari doesn't support absolute positioning on the div inside the foreignObject (it
+    * makes the foreignObject invisible), but absolute positioning is needed to place the
+    * resize control on the border. So we only set it and add the resize control on
+    * non-Safari browsers for now. Temporary fix; needs a better solution.
     */
     var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
     if(!isSafari) {
@@ -422,11 +418,12 @@ Text.prototype.addTextBox = function (groupId, importedObj) {
     }
     this.initDragElement();
 
-    // <textarea> has an intrinsic height (one row of its font). A <div> does
-    // not — when empty it collapses to zero height and the user wouldn't see
-    // an input area to click into. Initialize textHeight to one line's worth
-    // of height (font-size × line-height) so the input is visible immediately
-    // and so descenders ('p', 'g', etc.) aren't clipped by a too-tight height.
+    /**
+     * A <textarea> has an intrinsic one-row height; an empty <div> collapses to zero, so
+     * there'd be no visible area to click into. Initialize textHeight to one line
+     * (font-size × line-height) so the input shows immediately and descenders ('p', 'g')
+     * aren't clipped.
+     */
     var lineHeight = 1.4;
     var oneLineHeight = this._attrs["font-size"] * lineHeight;
     if (!this.textHeight) {
@@ -436,35 +433,31 @@ Text.prototype.addTextBox = function (groupId, importedObj) {
     textInput.style.minHeight = oneLineHeight + "px";
     textInput.style.lineHeight = lineHeight;
     textInput.style.fontSize = this._attrs["font-size"] + "px";
-    // contenteditable <div> shows a thicker default focus ring than <textarea>;
-    // suppress it (the textOuterDiv's border already signals the active text annotation).
+    // suppress the contenteditable focus ring; textOuterDiv's border already signals the active annotation
     textInput.style.outline = "none";
     textInput.style.whiteSpace = "pre-wrap";
     textInput.style.wordBreak = "break-word";
     textInput.style.cursor = "text";
-    // Don't constrain overflow on the input — auto-resize keeps it at content
-    // height; clipping descenders would just look like the bug above.
+    // don't constrain overflow; auto-resize keeps it at content height and clipping would hide descenders
     textInput.style.overflow = "visible";
-    /* Set the border and padding of the div oustide the textarea
-    * to create area for dragging the text annotation.
-    * The padding is set to 4 times the stroke width to create a draggable area for the div
+    /* border and padding on the outer div create a draggable area around the text;
+    * padding is 4× the stroke width.
     */
     textOuterDiv.style.padding = (this.parent.getStrokeScale() * this._ratio * 4) + "px";
     textOuterDiv.style.borderWidth = (this.parent.getStrokeScale() * this._ratio) + "px";
     textOuterDiv.style.borderStyle = "solid";
     textOuterDiv.style.borderColor = this._attrs["stroke"];
 
-    // Counter-rotate the wrapper so the text reads upright regardless of
-    // viewport rotation. resizeSVG also applies this on every rotation change;
-    // doing it here ensures the very first paint is correct (before any
-    // animation event fires).
-    //
-    // The rotation pivot is set at the text content's top-left, which is
-    // offset by (padding + border) inward from textOuterDiv's own top-left.
-    // After finalize, the <p> tag IS at that offset point (foreignObject is
-    // moved to absorb the offset). Keeping the pivot at the same screen
-    // location across edit/finalize avoids a position jump when the user
-    // clicks away to commit the text.
+    /**
+     * Counter-rotate the wrapper so the text reads upright regardless of viewport rotation.
+     * resizeSVG also applies this on every rotation change; doing it here makes the first
+     * paint correct (before any animation event fires).
+     *
+     * The pivot is the text content's top-left, offset by (padding + border) inward from
+     * textOuterDiv's top-left. After finalize the <p> sits at that offset point (the
+     * foreignObject moves to absorb it), so keeping the pivot at the same screen location
+     * across edit/finalize avoids a position jump when the user clicks away to commit.
+     */
     var viewerParent = this.parent.parent.parent;
     var initialRotation = viewerParent.osd.viewport.getRotation();
     var paddingPx = this.parent.getStrokeScale() * this._ratio * 4;
@@ -473,9 +466,10 @@ Text.prototype.addTextBox = function (groupId, importedObj) {
     textOuterDiv.style.transformOrigin = pivotOffset + "px " + pivotOffset + "px";
     textOuterDiv.style.transform = "rotate(" + (-initialRotation) + "deg)";
 
-    // Focus the input immediately so the user can start typing without a
-    // second click. Defer to the next tick so the element is fully inserted
-    // into the DOM (focus() on a detached element is a no-op in some browsers).
+    /**
+     * Focus the input so the user can type without a second click. Defer to the next tick
+     * so the element is fully in the DOM (focus() on a detached element is a no-op in some browsers).
+     */
     setTimeout(function () { textInput.focus(); }, 0);
 }
 
@@ -490,9 +484,10 @@ Text.prototype.changeFontSize = function (fontSize) {
 
     var foreignObj = this.getForeignObj();
     if (!foreignObj) return;
-    // Locate the input field by class rather than child index. With nested
-    // contenteditable elements, browsers can insert placeholder text/<br>
-    // nodes during focus, which knocks `childNodes[0]` off the expected node.
+    /**
+     * Locate the input by class rather than child index: nested contenteditable elements
+     * get browser-injected placeholder/<br> nodes on focus that knock childNodes[0] off.
+     */
     var textInput = foreignObj.querySelector(".text-foreign-object-input");
     if (!textInput || !textInput.style) return;
     textInput.style.fontSize = this._ratio * fontSize + "px";
@@ -538,9 +533,8 @@ Text.prototype.initDragElement = function () {
         pos4 = e.clientY;
 
         /**
-         * we have to add this event to the whole page and not the div.
-         * this way even if the cursor goes outside the div it's still considered a valid drag. we should only stop the
-         * drag when users actaully stops dragging (regardles of where the cursor is)
+         * Attach to the whole page, not the div, so the drag stays valid even when the
+         * cursor leaves the div; we only stop when the user actually stops dragging.
          */
         document.addEventListener('pointerup', closeDragElement);
 
@@ -564,12 +558,11 @@ Text.prototype.initDragElement = function () {
         var deltaScreenX = -pos1;
         var deltaScreenY = -pos2;
 
-        // The viewport may be rotated. The text's margin (marginLeft/marginTop)
-        // is in the SVG's local coord system, which is rotated by R relative
-        // to the screen. To make the text follow the pointer in screen space
-        // we have to rotate the screen-space delta by -R into margin-space.
-        // Without this, a right-drag at R=90 would move the text down (and
-        // similar gibberish at 180/270).
+        /**
+         * The margin (marginLeft/marginTop) is in the SVG's local coords, rotated by R
+         * relative to the screen. Rotate the screen-space delta by -R into margin-space so
+         * the text follows the pointer; without this a right-drag at R=90 moves it down.
+         */
         var rotation = _self.parent.parent.parent.osd.viewport.getRotation();
         var rad = rotation * Math.PI / 180;
         var cosR = Math.cos(rad);
@@ -609,8 +602,7 @@ Text.prototype.initResizeElement = function () {
     bottomright.style.height = this._attrs["font-size"] + "px";
     bottomright.style.width = this._attrs["font-size"] + "px";
     bottomright.style.backgroundColor = this._attrs["stroke"];
-    // To position the resize element exactly on the right border, we need to add a margin of 1/8th of the font size
-    // to the left of the element, since the padding of the div is 4 times the stroke width
+    // nudge the resizer onto the right border with a left margin of 1/8 the font size (the div's padding is 4× the stroke width)
     bottomright.style["margin-left"] = this._attrs["font-size"] * 0.125 + "px";
 
     // Function to intialize the resize movement of the text input
@@ -638,8 +630,7 @@ Text.prototype.initResizeElement = function () {
         divCont.style.position = "absolute";
         // Change the width of the text input based on the mouse movement
         divCont.style.width = startWidth + _self._ratio * (e.clientX - startX) + "px";
-        // The input field used to be a <textarea>; it is now a contenteditable
-        // <div>. Match on the class name so this keeps working either way.
+        // match the input by class (it's a contenteditable <div> now, formerly a <textarea>)
         var textArea = divCont.querySelector(".text-foreign-object-input");
         textArea.style.height = "1px";
         textArea.style.height = textArea.scrollHeight + "px";

--- a/js/viewer/annotation/text.js
+++ b/js/viewer/annotation/text.js
@@ -77,16 +77,21 @@ Text.prototype.positionAnnotation = function (point) {
 Text.prototype.transform = function () {
 
     var foreignObj = this.getForeignObj();
-    var div = foreignObj.childNodes[0];
-    const hasValue = div && div.childNodes[0] && div.childNodes[0].value && div.childNodes[0].value.trim() != "";
+    // Locate the wrapper and the input by class rather than child index. With
+    // nested contenteditable elements, browsers insert placeholder text / <br>
+    // nodes during focus that shift childNodes[0] away from the expected
+    // element — which previously made hasValue false and silently deleted the
+    // user's text on finalize.
+    var div = foreignObj.querySelector(".text-foreign-object-div");
+    var textInput = foreignObj.querySelector(".text-foreign-object-input");
+    const hasValue = textInput && textInput.innerText && textInput.innerText.trim() != "";
 
-    // if the textarea is empty, just remove the foreignObject
+    // if the input field is empty, just remove the foreignObject
     if (!hasValue) {
         foreignObj.parentNode.removeChild(foreignObj);
     }
     // Transform only if the input is not empty
     else {
-        var textInput = div.childNodes[0];
         var pText = this.createPTag(textInput, true);
 
         var h = div.style.marginTop;
@@ -124,6 +129,14 @@ Text.prototype.transform = function () {
         foreignObj.appendChild(pText);
         pText.style.height = "fit-content";
         pText.style.width = "fit-content";
+
+        // Carry over the counter-rotation that kept the editable wrapper
+        // upright. Without this, the freshly finalized <p> would briefly show
+        // rotated until the next resizeSVG/animation event runs.
+        var viewerParent = this.parent.parent.parent;
+        var rotation = viewerParent.osd.viewport.getRotation();
+        pText.style.transformOrigin = "0 0";
+        pText.style.transform = "rotate(" + (-rotation) + "deg)";
     }
 }
 
@@ -139,7 +152,11 @@ Text.prototype.createPTag = function (originalObj, isTextArea) {
 
     var _self = this;
     var pText = document.createElement("p");
-    var inputValue = isTextArea ? originalObj.value : originalObj.innerHTML;
+    // For the live editable input field (a contenteditable <div>) read innerText
+    // to preserve plain text content and avoid pulling in any browser-injected markup.
+    // For imported/saved annotations the originalObj is already a <p>, so innerHTML
+    // is the right read.
+    var inputValue = isTextArea ? originalObj.innerText : originalObj.innerHTML;
 
     /**
      * make sure the content of p tag stays withing the width, the same as textarea
@@ -303,7 +320,13 @@ Text.prototype.addTextBox = function (groupId, importedObj) {
 
     var svgForeignObj = document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject')
     var textOuterDiv = document.createElementNS("http://www.w3.org/1999/xhtml", "div");
-    var textInput = document.createElementNS("http://www.w3.org/1999/xhtml", "textarea");
+    // Use a contenteditable <div> (not <textarea>) for the input field. Native
+    // form widgets like <textarea> are rendered by the browser/OS in a way
+    // that bypasses CSS transforms on ancestor SVGs, so the text content
+    // wouldn't rotate with the rest of the annotation overlay when the
+    // viewport is rotated. A plain <div> is a regular DOM node and follows
+    // the parent .annotationSVG's CSS transform correctly.
+    var textInput = document.createElementNS("http://www.w3.org/1999/xhtml", "div");
     this.setForeignObj(svgForeignObj);
 
     fontSize = document.querySelector(".fontInput").value;
@@ -311,10 +334,13 @@ Text.prototype.addTextBox = function (groupId, importedObj) {
 
     // Set the attributes of the foreign object, div and textarea
     textInput.setAttribute("class", "text-foreign-object-input");
-    // Make the text area editable inside the foreign object in SVG by setting the contentEditable attribute
-    textOuterDiv.setAttribute("contentEditable", "true");
+    // Only the inner input div is editable. Previously textOuterDiv and the
+    // foreignObject were also contentEditable, which meant clicks in their
+    // padding/border landed there and typed text ended up outside the styled
+    // input field (no font-size / color inherited). With only textInput
+    // contenteditable, focus always lands in the input regardless of where the
+    // user clicks within the wrapper.
     textInput.setAttribute("contentEditable", "true");
-    svgForeignObj.setAttribute("contentEditable", "true");
     svgForeignObj.setAttribute("stroke", this._attrs["stroke"]);
     // Set the font color same as the stroke color
     textInput.style.color = this._attrs["stroke"];
@@ -346,11 +372,13 @@ Text.prototype.addTextBox = function (groupId, importedObj) {
      * Add event listeners to the textarea for input
      * - update the the height
      */
-    textInput.addEventListener("keydown", function (e) {
-        prev = this.textHeight;
-        this.style.height = (this.scrollHeight) + "px";
+    // Auto-resize the input field to fit its content as the user types.
+    // Use the `input` event (fires after the keystroke is applied, unlike
+    // `keydown` which fires before — so scrollHeight is accurate here).
+    textInput.addEventListener("input", function () {
+        this.style.height = "auto";
+        this.style.height = this.scrollHeight + "px";
         this.textHeight = this.scrollHeight;
-        textInput.innerHTML = textInput.value;
     });
 
     /*
@@ -367,9 +395,29 @@ Text.prototype.addTextBox = function (groupId, importedObj) {
     }
     this.initDragElement();
 
+    // <textarea> has an intrinsic height (one row of its font). A <div> does
+    // not — when empty it collapses to zero height and the user wouldn't see
+    // an input area to click into. Initialize textHeight to one line's worth
+    // of height (font-size × line-height) so the input is visible immediately
+    // and so descenders ('p', 'g', etc.) aren't clipped by a too-tight height.
+    var lineHeight = 1.4;
+    var oneLineHeight = this._attrs["font-size"] * lineHeight;
+    if (!this.textHeight) {
+        this.textHeight = oneLineHeight;
+    }
     textInput.style.height = this.textHeight + "px";
-    textInput.style.overflowY = "hidden";
+    textInput.style.minHeight = oneLineHeight + "px";
+    textInput.style.lineHeight = lineHeight;
     textInput.style.fontSize = this._attrs["font-size"] + "px";
+    // contenteditable <div> shows a thicker default focus ring than <textarea>;
+    // suppress it (the textOuterDiv's border already signals the active text annotation).
+    textInput.style.outline = "none";
+    textInput.style.whiteSpace = "pre-wrap";
+    textInput.style.wordBreak = "break-word";
+    textInput.style.cursor = "text";
+    // Don't constrain overflow on the input — auto-resize keeps it at content
+    // height; clipping descenders would just look like the bug above.
+    textInput.style.overflow = "visible";
     /* Set the border and padding of the div oustide the textarea
     * to create area for dragging the text annotation.
     * The padding is set to 4 times the stroke width to create a draggable area for the div
@@ -378,7 +426,30 @@ Text.prototype.addTextBox = function (groupId, importedObj) {
     textOuterDiv.style.borderWidth = (this.parent.getStrokeScale() * this._ratio) + "px";
     textOuterDiv.style.borderStyle = "solid";
     textOuterDiv.style.borderColor = this._attrs["stroke"];
-    textInput.setAttribute("wrap", "hard");
+
+    // Counter-rotate the wrapper so the text reads upright regardless of
+    // viewport rotation. resizeSVG also applies this on every rotation change;
+    // doing it here ensures the very first paint is correct (before any
+    // animation event fires).
+    //
+    // The rotation pivot is set at the text content's top-left, which is
+    // offset by (padding + border) inward from textOuterDiv's own top-left.
+    // After finalize, the <p> tag IS at that offset point (foreignObject is
+    // moved to absorb the offset). Keeping the pivot at the same screen
+    // location across edit/finalize avoids a position jump when the user
+    // clicks away to commit the text.
+    var viewerParent = this.parent.parent.parent;
+    var initialRotation = viewerParent.osd.viewport.getRotation();
+    var paddingPx = this.parent.getStrokeScale() * this._ratio * 4;
+    var borderPx = this.parent.getStrokeScale() * this._ratio;
+    var pivotOffset = paddingPx + borderPx;
+    textOuterDiv.style.transformOrigin = pivotOffset + "px " + pivotOffset + "px";
+    textOuterDiv.style.transform = "rotate(" + (-initialRotation) + "deg)";
+
+    // Focus the input immediately so the user can start typing without a
+    // second click. Defer to the next tick so the element is fully inserted
+    // into the DOM (focus() on a detached element is a no-op in some browsers).
+    setTimeout(function () { textInput.focus(); }, 0);
 }
 
 /**
@@ -391,9 +462,12 @@ Text.prototype.changeFontSize = function (fontSize) {
     this._attrs["font-size"] = this._ratio * fontSize;
 
     var foreignObj = this.getForeignObj();
-    var divCont = foreignObj.childNodes[0];
-    if(divCont == null) return;
-    var textInput = divCont.childNodes[0];
+    if (!foreignObj) return;
+    // Locate the input field by class rather than child index. With nested
+    // contenteditable elements, browsers can insert placeholder text/<br>
+    // nodes during focus, which knocks `childNodes[0]` off the expected node.
+    var textInput = foreignObj.querySelector(".text-foreign-object-input");
+    if (!textInput || !textInput.style) return;
     textInput.style.fontSize = this._ratio * fontSize + "px";
     textInput.style.height = "1px";
     textInput.style.height = textInput.scrollHeight + "px";
@@ -458,9 +532,27 @@ Text.prototype.initDragElement = function () {
         pos2 = pos4 - e.clientY;
         pos3 = e.clientX;
         pos4 = e.clientY;
+
+        // Screen-space drag delta (positive = pointer moved right/down).
+        var deltaScreenX = -pos1;
+        var deltaScreenY = -pos2;
+
+        // The viewport may be rotated. The text's margin (marginLeft/marginTop)
+        // is in the SVG's local coord system, which is rotated by R relative
+        // to the screen. To make the text follow the pointer in screen space
+        // we have to rotate the screen-space delta by -R into margin-space.
+        // Without this, a right-drag at R=90 would move the text down (and
+        // similar gibberish at 180/270).
+        var rotation = _self.parent.parent.parent.osd.viewport.getRotation();
+        var rad = rotation * Math.PI / 180;
+        var cosR = Math.cos(rad);
+        var sinR = Math.sin(rad);
+        var deltaMarginX =  cosR * deltaScreenX + sinR * deltaScreenY;
+        var deltaMarginY = -sinR * deltaScreenX + cosR * deltaScreenY;
+
         // Set the element's new position:
-        divCont.style.marginLeft = divCont.offsetLeft - _self._ratio * pos1 + "px";
-        divCont.style.marginTop = divCont.offsetTop - _self._ratio * pos2 + "px";
+        divCont.style.marginLeft = (divCont.offsetLeft + _self._ratio * deltaMarginX) + "px";
+        divCont.style.marginTop  = (divCont.offsetTop  + _self._ratio * deltaMarginY) + "px";
     }
 
     // This function is called when the user stops dragging the element
@@ -519,7 +611,9 @@ Text.prototype.initResizeElement = function () {
         divCont.style.position = "absolute";
         // Change the width of the text input based on the mouse movement
         divCont.style.width = startWidth + _self._ratio * (e.clientX - startX) + "px";
-        var textArea = divCont.querySelector("textarea");
+        // The input field used to be a <textarea>; it is now a contenteditable
+        // <div>. Match on the class name so this keeps working either way.
+        var textArea = divCont.querySelector(".text-foreign-object-input");
         textArea.style.height = "1px";
         textArea.style.height = textArea.scrollHeight + "px";
 

--- a/js/viewer/annotation/text.js
+++ b/js/viewer/annotation/text.js
@@ -97,9 +97,6 @@ Text.prototype.transform = function () {
         var h = div.style.marginTop;
         var w = div.style.marginLeft;
 
-        foreignObj.setAttribute('width', pText.style.width);
-        foreignObj.setAttribute('height', pText.style.height);
-
         var divPadding = window.getComputedStyle(div, null).getPropertyValue('padding');
         // We obtain the padding and border of the div element to position the p tag correctly
         // Both properties have been defined in pixels while creating the textarea
@@ -127,6 +124,17 @@ Text.prototype.transform = function () {
         foreignObj.setAttribute("tabindex", -1);
         foreignObj.innerHTML = "";
         foreignObj.appendChild(pText);
+
+        // Size the foreignObject to fit pText exactly. We measure pText after
+        // it's in the DOM (so layout reflects the real <p>, not the contenteditable
+        // <div> it replaced) and use offsetWidth/Height because they ignore CSS
+        // transforms — getBoundingClientRect would return a rotated AABB at
+        // non-zero viewport rotation. offsetWidth/Height are integer-rounded
+        // (floor), so +1 covers the sub-pixel rounding.
+        pText.style.width = "max-content";
+        pText.style.height = "auto";
+        foreignObj.setAttribute('width', (pText.offsetWidth + 1) + 'px');
+        foreignObj.setAttribute('height', (pText.offsetHeight + 1) + 'px');
         pText.style.height = "fit-content";
         pText.style.width = "fit-content";
 
@@ -193,6 +201,25 @@ Text.prototype.createPTag = function (originalObj, isTextArea) {
 
     // Copy the font color of the textarea to the p tag
     pText.style.color = styleObj["color"];
+
+    // For imported (saved) text, preserve the rotation that was baked in at
+    // finalize time. transform() in this file applies `rotate(-R0)` to the
+    // <p> at finalize so subsequent viewport rotation produces a visible
+    // rotation of (R - R0) — i.e. the text is "stickied" to the image's
+    // orientation at creation time. Without copying it here, reload paths
+    // through createPTag drop the transform and the text appears un-rotated.
+    //
+    // Only the imported case needs this; transform() applies the transform
+    // itself after createPTag returns for the live finalize path.
+    if (!isTextArea) {
+        if (styleObj["transform"]) {
+            pText.style.transform = styleObj["transform"];
+        }
+        if (styleObj["transform-origin"]) {
+            pText.style.transformOrigin = styleObj["transform-origin"];
+        }
+    }
+
     // Adding the text-hover class to the p tag for the hover effect to highlight the text
     pText.classList.add("text-hover");
 

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -91,6 +91,10 @@ function Viewer(parent, config) {
         // after each change, make sure svgs are properly positioned
         this.osd.addHandler('animation', this.resizeSVG);
 
+        // setRotation does not animate a spring, so it does not fire 'animation'.
+        // Subscribe to 'rotate' so the overlay follows viewport rotation.
+        this.osd.addHandler('rotate', this.resizeSVG);
+
         // zoom on double click
         this.osd.addHandler('canvas-double-click', this.zoomIn.bind(this));
 
@@ -1500,13 +1504,13 @@ function Viewer(parent, config) {
     // Toggle by commenting/uncommenting the bodies. Keep exactly one active.
     this.rotateBy = function (degrees) {
         // --- animated ---
-        // var current = this.osd.viewport.getRotation();
-        // this._animateRotation(current, current + degrees, 300);
+        var current = this.osd.viewport.getRotation();
+        this._animateRotation(current, current + degrees, 300);
 
         // --- instant (snap) ---
-        var current = this.osd.viewport.getRotation();
-        this.osd.viewport.setRotation(current + degrees);
-        this.osd.viewport.applyConstraints();
+        // var current = this.osd.viewport.getRotation();
+        // this.osd.viewport.setRotation(current + degrees);
+        // this.osd.viewport.applyConstraints();
     }
 
     // Reset the OSD viewport rotation back to 0 degrees. Same two-mode pattern
@@ -1514,13 +1518,13 @@ function Viewer(parent, config) {
     this.resetRotation = function () {
         // --- animated (shortest path back to 0; e.g. 270° animates +90° through
         // 360 instead of going the long way back) ---
-        // var current = this.osd.viewport.getRotation();
-        // var target = current > 180 ? 360 : 0;
-        // this._animateRotation(current, target, 300);
+        var current = this.osd.viewport.getRotation();
+        var target = current > 180 ? 360 : 0;
+        this._animateRotation(current, target, 300);
 
         // --- instant (snap) ---
-        this.osd.viewport.setRotation(0);
-        this.osd.viewport.applyConstraints();
+        // this.osd.viewport.setRotation(0);
+        // this.osd.viewport.applyConstraints();
     }
 
     // requestAnimationFrame handle for the in-progress rotation tween, if any.
@@ -1622,29 +1626,120 @@ function Viewer(parent, config) {
             var ignoreDimension = svgs[i].getAttribute("ignoreDimension") == "false" ? false : true;
             var scale = svgs[i].getAttribute("scale") ? parseFloat(svgs[i].getAttribute("scale")) : false;
             var viewBox = svgs[i].getAttribute("viewBox").split(" ").map(function(value){ return +value});
-            // console.log(viewBox);
-            var topLeft = ignoreReferencePoint ? {x: 0, y : 0 } : {x: viewBox[0], y : viewBox[1] };
-            var bottomRight = ignoreDimension ? {x: size.x, y : size.y } : {x: topLeft.x + viewBox[2], y : topLeft.y + viewBox[3]};
-            // var topLeft = {x: _self.osd.world.getItemAt(1).getBounds(true).x + _self.osd.world.getItemAt(0).getBounds(true).x, y : 0 };
-            // var bottomRight = {x: topLeft.x + size.x, y : topLeft.y + size.y};
 
-            // not ignoring the reference point and the scale is provided
-            if(scale){
-                if(!ignoreReferencePoint){
-                    topLeft.x = topLeft.x / scale;
-                    topLeft.y = topLeft.y / scale;
+            // Image-space rectangle this SVG covers. We project three corners (TL, TR, BL)
+            // so the SVG can be sized along the image's natural axes regardless of viewport
+            // rotation. With only two opposing corners (TL, BR), width/height go negative
+            // under 90°/270° rotations.
+            var imgTL = ignoreReferencePoint ? {x: 0, y: 0} : {x: viewBox[0], y: viewBox[1]};
+            var imgBR = ignoreDimension
+                ? {x: size.x, y: size.y}
+                : {x: imgTL.x + viewBox[2], y: imgTL.y + viewBox[3]};
+
+            // Legacy SVG-import path: viewBox stored in pre-scaled coords.
+            if (scale) {
+                if (!ignoreReferencePoint) {
+                    imgTL.x = imgTL.x / scale;
+                    imgTL.y = imgTL.y / scale;
                 }
-                if(!ignoreDimension){
-                    bottomRight.x = bottomRight.x / scale;
-                    bottomRight.y = bottomRight.y / scale;
+                if (!ignoreDimension) {
+                    imgBR.x = imgBR.x / scale;
+                    imgBR.y = imgBR.y / scale;
                 }
             }
-            topLeft = w.imageToViewerElementCoordinates(new OpenSeadragon.Point(topLeft.x, topLeft.y));
-            bottomRight = w.imageToViewerElementCoordinates(new OpenSeadragon.Point(bottomRight.x, bottomRight.y));
-            svgs[i].setAttribute("x", topLeft.x + "px");
-            svgs[i].setAttribute("y", topLeft.y + "px");
-            svgs[i].setAttribute("width", bottomRight.x - topLeft.x + "px");
-            svgs[i].setAttribute("height", bottomRight.y - topLeft.y + "px");
+            var imgTR = {x: imgBR.x, y: imgTL.y};
+            var imgBL = {x: imgTL.x, y: imgBR.y};
+
+            // imageToViewerElementCoordinates is rotation-aware: it returns the rotated
+            // on-screen position of each image-space corner.
+            var scrTL = w.imageToViewerElementCoordinates(new OpenSeadragon.Point(imgTL.x, imgTL.y));
+            var scrTR = w.imageToViewerElementCoordinates(new OpenSeadragon.Point(imgTR.x, imgTR.y));
+            var scrBL = w.imageToViewerElementCoordinates(new OpenSeadragon.Point(imgBL.x, imgBL.y));
+
+            // Rotation is rigid (preserves distances), so distances between these
+            // projected corners equal the on-screen width/height of the un-rotated image.
+            var width = Math.hypot(scrTR.x - scrTL.x, scrTR.y - scrTL.y);
+            var height = Math.hypot(scrBL.x - scrTL.x, scrBL.y - scrTL.y);
+            var rotation = _self.osd.viewport.getRotation();
+
+            // Place the SVG at the image's rotated top-left on screen, size it along the
+            // image's natural axes, then rotate around that same point so the SVG aligns
+            // with the rotated image. Shape geometry inside (image-coord viewBox) is
+            // unchanged. At rotation === 0 this is identical to the previous behavior.
+            //
+            // Rotation pivot is encoded directly into the transform via translate/rotate/
+            // translate rather than `transform-origin`: nested <svg> elements interpret
+            // `transform-box: view-box` differently across browsers (Firefox uses the
+            // parent SVG's viewport, Chromium uses the element's own), which makes
+            // `transform-origin: 0 0` land on the wrong point. The translate trick
+            // pivots around (scrTL.x, scrTL.y) regardless of those defaults.
+            svgs[i].setAttribute("x", scrTL.x + "px");
+            svgs[i].setAttribute("y", scrTL.y + "px");
+            svgs[i].setAttribute("width", width + "px");
+            svgs[i].setAttribute("height", height + "px");
+            svgs[i].style.transform =
+                "translate(" + scrTL.x + "px, " + scrTL.y + "px) " +
+                "rotate(" + rotation + "deg) " +
+                "translate(" + (-scrTL.x) + "px, " + (-scrTL.y) + "px)";
+
+            // Counter-rotate each text annotation so the text stays upright
+            // regardless of viewport rotation. Combined with the parent SVG's
+            // rotate(R) the net visual rotation is 0, while the anchor stays
+            // glued to the rotated image coordinate.
+            //
+            // The rotation pivot has to point at the text-content's top-left
+            // in both states:
+            //   - editing: wrapper is .text-foreign-object-div, whose top-left
+            //     is OUTSIDE the text content by (padding + border). Pivot
+            //     must be at that inward offset.
+            //   - finalized: wrapper is a bare <p>, whose top-left IS the
+            //     text content. Pivot is at 0 0.
+            // Aligning the pivot keeps the text from jumping on finalize.
+            var textForeignObjects = svgs[i].querySelectorAll(".text-foreign-object");
+            for (var j = 0; j < textForeignObjects.length; j++) {
+                var inner = textForeignObjects[j].firstElementChild;
+                if (!inner || !inner.style) continue;
+                var originX = 0, originY = 0;
+                if (inner.classList && inner.classList.contains("text-foreign-object-div")) {
+                    var cs = getComputedStyle(inner);
+                    originX = (parseFloat(cs.paddingLeft) || 0) + (parseFloat(cs.borderLeftWidth) || 0);
+                    originY = (parseFloat(cs.paddingTop) || 0) + (parseFloat(cs.borderTopWidth) || 0);
+                }
+                inner.style.transformOrigin = originX + "px " + originY + "px";
+                inner.style.transform = "rotate(" + (-rotation) + "deg)";
+            }
+
+            // TODO(rotation-debug): remove after rotation overlay is verified
+            if (window.__rotationDebug) {
+                var r = function(v){ return Math.round(v * 100) / 100; };
+                var bbox = svgs[i].getBoundingClientRect();
+                var cs = getComputedStyle(svgs[i]);
+                var parentBbox = svgs[i].parentNode && svgs[i].parentNode.getBoundingClientRect
+                    ? svgs[i].parentNode.getBoundingClientRect()
+                    : null;
+                console.log(
+                    "[resizeSVG]",
+                    "idx=" + i,
+                    "rot=" + rotation,
+                    "imgTL=(" + r(imgTL.x) + "," + r(imgTL.y) + ")",
+                    "imgBR=(" + r(imgBR.x) + "," + r(imgBR.y) + ")",
+                    "scrTL=(" + r(scrTL.x) + "," + r(scrTL.y) + ")",
+                    "scrTR=(" + r(scrTR.x) + "," + r(scrTR.y) + ")",
+                    "scrBL=(" + r(scrBL.x) + "," + r(scrBL.y) + ")",
+                    "w=" + r(width),
+                    "h=" + r(height),
+                    "bbox=(" + r(bbox.x) + "," + r(bbox.y) + ") " + r(bbox.width) + "x" + r(bbox.height),
+                    "parentBbox=" + (parentBbox ? "(" + r(parentBbox.x) + "," + r(parentBbox.y) + ") " + r(parentBbox.width) + "x" + r(parentBbox.height) : "n/a"),
+                    "tBox=" + cs.transformBox,
+                    "tOrig=" + cs.transformOrigin,
+                    "t=" + cs.transform,
+                    "overflow=" + cs.overflow,
+                    "parentOverflow=" + (svgs[i].parentNode ? getComputedStyle(svgs[i].parentNode).overflow : "n/a"),
+                    "visibility=" + cs.visibility,
+                    "display=" + cs.display,
+                    "shapeCount=" + svgs[i].querySelectorAll("g, rect, circle, polygon, polyline, path, line, foreignObject").length
+                );
+            }
         }
     }
 

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -678,14 +678,11 @@ function Viewer(parent, config) {
     }
 
     /**
-     * Export the displayed view of osd viewer to a jpg file.
-     * Apart from the osd canvas, it will also add the svg overlays
-     * This function will trigger a browser download after processing is done.
-     * The messages that will be displatched by this function:
-     *  - `downloadViewDone`: when download is done.
-     *  - `downloadViewError`: if we encounter an error.
+     * Export the displayed view (osd canvas + svg annotation overlays) to a
+     * jpg file and trigger a browser download. Dispatches `downloadViewDone`
+     * on success, `downloadViewError` on failure.
      *
-     * @param {String=} fileName - the name of the file that will be downloaded
+     * @param {String=} fileName
      */
     this.exportViewToJPG = function (fileName) {
         fileName = fileName ? (fileName + ".jpg") : ("osd_" + Date.parse(new Date()) + ".jpg");
@@ -693,26 +690,20 @@ function Viewer(parent, config) {
         var self = this,
             canvas, newCanvas, newCtx, rawImg, errored = false,
             svgProcessedCount = 0, svgTotalCount = 0,
-            svgAttrs = ["x", "y", "width", "height"], svgDimension = [], svgAttr;
+            svgAttrs = ["x", "y", "width", "height"], svgAttr;
 
         var channelArray = [];
-
         if (_self._showChannelNamesOverlay) {
             for (id in this.channels) {
                 if (this.channels[id].isDisplay) {
-                    channelArray.push([this.channels[id].name, this.channels[id].getOverlayColor()])
+                    channelArray.push([this.channels[id].name, this.channels[id].getOverlayColor()]);
                 }
             }
         }
 
-        // add watermark and download the file
         var finalize = function () {
             if (errored) return;
-
-            // add the water mark to the image
             self._utils.addWaterMark2Canvas(newCanvas, self.parameters.waterMark, self.osd.scalebarInstance, channelArray);
-
-            // turn it into an image
             rawImg = newCanvas.toDataURL("image/jpeg", 1);
             if (rawImg) {
                 self._utils.downloadAsFile(fileName, rawImg, "image/jpeg");
@@ -721,22 +712,18 @@ function Viewer(parent, config) {
                 // TODO proper error object
                 self.dispatchEvent('downloadViewError', new Error("Empty image"));
             }
-        }
+        };
 
-        // get the displayed osd canvas
         if (this.osd.scalebarInstance.pixelsPerMeter) {
             canvas = this.osd.scalebarInstance.getImageWithScalebarAsCanvas();
         } else {
             canvas = self.osd.drawer.canvas;
         }
 
-        // create a canvas the same size as the displayed osd canvas
         newCanvas = document.createElement("canvas");
         newCanvas.width = canvas.width;
         newCanvas.height = canvas.height;
         newCtx = newCanvas.getContext("2d");
-
-        // add the osd canvas content to the new canvas
         newCtx.drawImage(canvas, 0, 0, canvas.width, canvas.height, 0, 0, canvas.width, canvas.height);
 
         if (!_self.svg) {
@@ -744,53 +731,84 @@ function Viewer(parent, config) {
             return;
         }
 
-        // add the svg overlays to the new canvas by converting them to image
         // TODO should be refactored
         var svgs = _self.svg.querySelectorAll(".annotationSVG");
         var pixelRatio = self._utils.queryForRetina(newCanvas);
+        // Snapshot rotation once so all SVGs are drawn against a consistent value.
+        var rotation = _self.osd.viewport.getRotation();
+        var rotationRad = rotation * Math.PI / 180;
+        // External CSS isn't applied during standalone rasterization, so inline
+        // these resolved styles onto each <p> before serializing.
+        var TEXT_FONT_PROPS = ['font-family', 'font-weight', 'font-style', 'line-height'];
+
         svgs.forEach(function (svg) {
             svgTotalCount++;
+
+            // resizeSVG's CSS transform pivots around screen-space coords that
+            // don't exist outside the live DOM; strip it and re-apply rotation
+            // via the canvas context below.
+            var svgClone = svg.cloneNode(true);
+            svgClone.style.transform = '';
+
+            var origPs = svg.querySelectorAll('foreignObject p');
+            var clonePs = svgClone.querySelectorAll('foreignObject p');
+            for (var pi = 0; pi < origPs.length && pi < clonePs.length; pi++) {
+                var cs = getComputedStyle(origPs[pi]);
+                for (var fi = 0; fi < TEXT_FONT_PROPS.length; fi++) {
+                    clonePs[pi].style.setProperty(TEXT_FONT_PROPS[fi], cs.getPropertyValue(TEXT_FONT_PROPS[fi]));
+                }
+            }
+
+            // foreignObject defaults to overflow:hidden; the live CSS rule
+            // setting it visible isn't available standalone.
+            var clonedFOs = svgClone.querySelectorAll('foreignObject');
+            for (var fo = 0; fo < clonedFOs.length; fo++) {
+                clonedFOs[fo].setAttribute('overflow', 'visible');
+            }
+
+            var dims = [];
             var img = new Image();
             img.onload = function(e) {
                 if (errored) return;
 
                 svgAttrs.forEach(function (attrName) {
                     svgAttr = svg.getAttribute(attrName);
-                    if (svgAttr == null) {
-                        svgAttr = 0;
-                    }
-                    if (typeof svgAttr === "string") {
-                        svgAttr = svgAttr.replace("px", "");
-                    }
-                    // osd is property handling pixel ratio, so we don't need to change the canvas settings.
-                    // instead while drawing the annotation manually on top of the canvas, we should take care of pixelRatio
-                    svgDimension.push(Number(svgAttr) * pixelRatio);
+                    if (svgAttr == null) svgAttr = 0;
+                    if (typeof svgAttr === "string") svgAttr = svgAttr.replace("px", "");
+                    // osd handles its own pixelRatio; we apply it manually when drawing the annotation.
+                    dims.push(Number(svgAttr) * pixelRatio);
                 });
 
-                // add the image to new canvas
-                newCtx.drawImage(e.target, svgDimension[0], svgDimension[1], svgDimension[2], svgDimension[3]);
+                // Rotate around the SVG's screen-space top-left (matches the DOM transform that resizeSVG sets).
+                if (rotation !== 0) {
+                    newCtx.save();
+                    newCtx.translate(dims[0], dims[1]);
+                    newCtx.rotate(rotationRad);
+                    newCtx.translate(-dims[0], -dims[1]);
+                }
 
-                svgProcessedCount++
+                newCtx.drawImage(e.target, dims[0], dims[1], dims[2], dims[3]);
+
+                if (rotation !== 0) newCtx.restore();
+
+                svgProcessedCount++;
                 if (svgProcessedCount === svgTotalCount) {
                     finalize();
                 }
             };
             img.onerror = function (message, source, lineno, colno, error) {
                 console.log(error);
-
-                // only one error message is enough.
                 if (errored) return;
                 errored = true;
-
                 // TODO proper error object
                 self.dispatchEvent('downloadViewError', error);
-            }
-            // NOTE source has to be defined after onload and onerror
+            };
+            // src must be set after onload/onerror
             img.src = null;
-            img.src = "data:image/svg+xml;utf8," + encodeURIComponent(new XMLSerializer().serializeToString(svg));
+            img.src = "data:image/svg+xml;utf8," + encodeURIComponent(new XMLSerializer().serializeToString(svgClone));
         });
 
-        // in case there wasn't any svg overlays
+        // no svg overlays
         if (svgProcessedCount === svgTotalCount) {
             finalize();
         }
@@ -1504,13 +1522,13 @@ function Viewer(parent, config) {
     // Toggle by commenting/uncommenting the bodies. Keep exactly one active.
     this.rotateBy = function (degrees) {
         // --- animated ---
-        var current = this.osd.viewport.getRotation();
-        this._animateRotation(current, current + degrees, 300);
+        // var current = this.osd.viewport.getRotation();
+        // this._animateRotation(current, current + degrees, 300);
 
         // --- instant (snap) ---
-        // var current = this.osd.viewport.getRotation();
-        // this.osd.viewport.setRotation(current + degrees);
-        // this.osd.viewport.applyConstraints();
+        var current = this.osd.viewport.getRotation();
+        this.osd.viewport.setRotation(current + degrees);
+        this.osd.viewport.applyConstraints();
     }
 
     // Reset the OSD viewport rotation back to 0 degrees. Same two-mode pattern
@@ -1518,13 +1536,13 @@ function Viewer(parent, config) {
     this.resetRotation = function () {
         // --- animated (shortest path back to 0; e.g. 270° animates +90° through
         // 360 instead of going the long way back) ---
-        var current = this.osd.viewport.getRotation();
-        var target = current > 180 ? 360 : 0;
-        this._animateRotation(current, target, 300);
+        // var current = this.osd.viewport.getRotation();
+        // var target = current > 180 ? 360 : 0;
+        // this._animateRotation(current, target, 300);
 
         // --- instant (snap) ---
-        // this.osd.viewport.setRotation(0);
-        // this.osd.viewport.applyConstraints();
+        this.osd.viewport.setRotation(0);
+        this.osd.viewport.applyConstraints();
     }
 
     // requestAnimationFrame handle for the in-progress rotation tween, if any.
@@ -1593,50 +1611,33 @@ function Viewer(parent, config) {
 
     // Resize Annotation SVGs
     this.resizeSVG = function(){
-        // this might be called while we're changing the main image
+        // may be called while the main image is being swapped out
         if (_self.osd.world.getItemCount() == 0) return;
 
         var svgs = _self.svg.querySelectorAll(".annotationSVG"),
-            // upperLeftPoint,
-            // bottomRightPoint,
             i,
             w = _self.osd.world.getItemAt(0),
-            size = w.getContentSize(),
-            strokeScale = null;
+            size = w.getContentSize();
 
-        // removed the if condition because the function would need to change if the window has been resized
         _self.strokeWidthScale = _self.getStrokeWidthScaleFunction();
-
-        strokeScale = _self.strokeWidthScale(_self.osd.viewport.getZoom())
+        var strokeScale = _self.strokeWidthScale(_self.osd.viewport.getZoom());
         _self.changeStrokeScale(strokeScale);
-        _self.dispatchEvent("onChangeStrokeScale", {
-            "strokeScale" : strokeScale
-        });
+        _self.dispatchEvent("onChangeStrokeScale", { "strokeScale" : strokeScale });
+
+        var rotation = _self.osd.viewport.getRotation();
 
         for(i = 0; i < svgs.length; i++){
-            // upperLeftPoint = svgs[i].getAttribute("upperLeftPoint").split(",") || [];
-            // bottomRightPoint = svgs[i].getAttribute("bottomRightPoint").split(",") || [];
-            // if(upperLeftPoint.length == 0 || bottomRightPoint.length == 0){
-            //     continue;
-            // }
-            // upperLeftPoint = _self.osd.viewport.pixelFromPoint(new OpenSeadragon.Point(+upperLeftPoint[0], +upperLeftPoint[1]), true);
-            // bottomRightPoint = _self.osd.viewport.pixelFromPoint(new OpenSeadragon.Point(+bottomRightPoint[0], +bottomRightPoint[1]), true);
-
             var ignoreReferencePoint = svgs[i].getAttribute("ignoreReferencePoint") == "false" ? false : true;
             var ignoreDimension = svgs[i].getAttribute("ignoreDimension") == "false" ? false : true;
             var scale = svgs[i].getAttribute("scale") ? parseFloat(svgs[i].getAttribute("scale")) : false;
-            var viewBox = svgs[i].getAttribute("viewBox").split(" ").map(function(value){ return +value});
+            var viewBox = svgs[i].getAttribute("viewBox").split(" ").map(function(value){ return +value; });
 
-            // Image-space rectangle this SVG covers. We project three corners (TL, TR, BL)
-            // so the SVG can be sized along the image's natural axes regardless of viewport
-            // rotation. With only two opposing corners (TL, BR), width/height go negative
-            // under 90°/270° rotations.
             var imgTL = ignoreReferencePoint ? {x: 0, y: 0} : {x: viewBox[0], y: viewBox[1]};
             var imgBR = ignoreDimension
                 ? {x: size.x, y: size.y}
                 : {x: imgTL.x + viewBox[2], y: imgTL.y + viewBox[3]};
 
-            // Legacy SVG-import path: viewBox stored in pre-scaled coords.
+            // legacy SVG-import path with a pre-scaled viewBox
             if (scale) {
                 if (!ignoreReferencePoint) {
                     imgTL.x = imgTL.x / scale;
@@ -1647,32 +1648,20 @@ function Viewer(parent, config) {
                     imgBR.y = imgBR.y / scale;
                 }
             }
+
+            // Project three corners so width/height stay positive at every rotation —
+            // with only two opposing corners they go negative at 90°/270°.
             var imgTR = {x: imgBR.x, y: imgTL.y};
             var imgBL = {x: imgTL.x, y: imgBR.y};
-
-            // imageToViewerElementCoordinates is rotation-aware: it returns the rotated
-            // on-screen position of each image-space corner.
             var scrTL = w.imageToViewerElementCoordinates(new OpenSeadragon.Point(imgTL.x, imgTL.y));
             var scrTR = w.imageToViewerElementCoordinates(new OpenSeadragon.Point(imgTR.x, imgTR.y));
             var scrBL = w.imageToViewerElementCoordinates(new OpenSeadragon.Point(imgBL.x, imgBL.y));
-
-            // Rotation is rigid (preserves distances), so distances between these
-            // projected corners equal the on-screen width/height of the un-rotated image.
             var width = Math.hypot(scrTR.x - scrTL.x, scrTR.y - scrTL.y);
             var height = Math.hypot(scrBL.x - scrTL.x, scrBL.y - scrTL.y);
-            var rotation = _self.osd.viewport.getRotation();
 
-            // Place the SVG at the image's rotated top-left on screen, size it along the
-            // image's natural axes, then rotate around that same point so the SVG aligns
-            // with the rotated image. Shape geometry inside (image-coord viewBox) is
-            // unchanged. At rotation === 0 this is identical to the previous behavior.
-            //
-            // Rotation pivot is encoded directly into the transform via translate/rotate/
-            // translate rather than `transform-origin`: nested <svg> elements interpret
-            // `transform-box: view-box` differently across browsers (Firefox uses the
-            // parent SVG's viewport, Chromium uses the element's own), which makes
-            // `transform-origin: 0 0` land on the wrong point. The translate trick
-            // pivots around (scrTL.x, scrTL.y) regardless of those defaults.
+            // Pivot is encoded as translate/rotate/translate rather than transform-origin
+            // because nested <svg> elements treat `transform-box: view-box` inconsistently
+            // across browsers; the translate trick pivots around (scrTL.x, scrTL.y) anyway.
             svgs[i].setAttribute("x", scrTL.x + "px");
             svgs[i].setAttribute("y", scrTL.y + "px");
             svgs[i].setAttribute("width", width + "px");
@@ -1682,19 +1671,9 @@ function Viewer(parent, config) {
                 "rotate(" + rotation + "deg) " +
                 "translate(" + (-scrTL.x) + "px, " + (-scrTL.y) + "px)";
 
-            // Counter-rotate the EDITABLE text wrappers (.text-foreign-object-div)
-            // so the user can always type left-to-right regardless of viewport
-            // rotation. The pivot is at the text content's top-left (offset
-            // inward from the wrapper's top-left by padding + border) so that
-            // on finalize the visible position doesn't jump.
-            //
-            // Finalized text (<p>) is intentionally NOT touched here.
-            // text.js#transform() bakes a `rotate(-R0)` into the <p> at the
-            // moment of finalize, where R0 is the viewport rotation at that
-            // moment. Combined with the parent SVG's current rotation R, the
-            // visible rotation of the text is (R - R0) — so it's "stickied"
-            // to the image's orientation at creation time and rotates with
-            // subsequent viewport changes like any other shape annotation.
+            // Counter-rotate the editable text wrapper so typing stays left-to-right.
+            // Finalized text (<p>) is intentionally skipped — its own inline rotate(-R0)
+            // keeps it stickied to the image's orientation at creation time.
             var textForeignObjects = svgs[i].querySelectorAll(".text-foreign-object");
             for (var j = 0; j < textForeignObjects.length; j++) {
                 var inner = textForeignObjects[j].firstElementChild;
@@ -1705,38 +1684,6 @@ function Viewer(parent, config) {
                 var originY = (parseFloat(cs.paddingTop) || 0) + (parseFloat(cs.borderTopWidth) || 0);
                 inner.style.transformOrigin = originX + "px " + originY + "px";
                 inner.style.transform = "rotate(" + (-rotation) + "deg)";
-            }
-
-            // TODO(rotation-debug): remove after rotation overlay is verified
-            if (window.__rotationDebug) {
-                var r = function(v){ return Math.round(v * 100) / 100; };
-                var bbox = svgs[i].getBoundingClientRect();
-                var cs = getComputedStyle(svgs[i]);
-                var parentBbox = svgs[i].parentNode && svgs[i].parentNode.getBoundingClientRect
-                    ? svgs[i].parentNode.getBoundingClientRect()
-                    : null;
-                console.log(
-                    "[resizeSVG]",
-                    "idx=" + i,
-                    "rot=" + rotation,
-                    "imgTL=(" + r(imgTL.x) + "," + r(imgTL.y) + ")",
-                    "imgBR=(" + r(imgBR.x) + "," + r(imgBR.y) + ")",
-                    "scrTL=(" + r(scrTL.x) + "," + r(scrTL.y) + ")",
-                    "scrTR=(" + r(scrTR.x) + "," + r(scrTR.y) + ")",
-                    "scrBL=(" + r(scrBL.x) + "," + r(scrBL.y) + ")",
-                    "w=" + r(width),
-                    "h=" + r(height),
-                    "bbox=(" + r(bbox.x) + "," + r(bbox.y) + ") " + r(bbox.width) + "x" + r(bbox.height),
-                    "parentBbox=" + (parentBbox ? "(" + r(parentBbox.x) + "," + r(parentBbox.y) + ") " + r(parentBbox.width) + "x" + r(parentBbox.height) : "n/a"),
-                    "tBox=" + cs.transformBox,
-                    "tOrig=" + cs.transformOrigin,
-                    "t=" + cs.transform,
-                    "overflow=" + cs.overflow,
-                    "parentOverflow=" + (svgs[i].parentNode ? getComputedStyle(svgs[i].parentNode).overflow : "n/a"),
-                    "visibility=" + cs.visibility,
-                    "display=" + cs.display,
-                    "shapeCount=" + svgs[i].querySelectorAll("g, rect, circle, polygon, polyline, path, line, foreignObject").length
-                );
             }
         }
     }

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -694,7 +694,7 @@ function Viewer(parent, config) {
 
         var channelArray = [];
         if (_self._showChannelNamesOverlay) {
-            for (id in this.channels) {
+            for (var id in this.channels) {
                 if (this.channels[id].isDisplay) {
                     channelArray.push([this.channels[id].name, this.channels[id].getOverlayColor()]);
                 }

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -1109,6 +1109,8 @@ function Viewer(parent, config) {
                 tileSource: tileSource,
                 compositeOperation: 'lighter',
                 opacity: (channel["isDisplay"] ? 1 : 0),
+                // TODO: rotation - per-image rotation (clockwise, around top-left)
+                degrees: 0,
             });
         }
 
@@ -1196,6 +1198,8 @@ function Viewer(parent, config) {
                 tileSource: tileSource,
                 compositeOperation: 'lighter',
                 opacity: (channel["isDisplay"] ? 1 : 0),
+                // TODO: rotation - per-image rotation (clockwise, around top-left)
+                degrees: 0,
             });
         }
 
@@ -1486,6 +1490,73 @@ function Viewer(parent, config) {
     this.resetHomeView = function () {
         this.osd.viewport.goHome();
         this.osd.viewport.applyConstraints();
+    }
+
+    // Rotate the OSD viewport by the given delta in degrees. Positive values are
+    // clockwise; negative values counterclockwise. Note: this only rotates the
+    // scene. SVG annotation overlays don't follow yet (TODO).
+    //
+    // Two implementations below: animated (smooth tween) and instant (snap).
+    // Toggle by commenting/uncommenting the bodies. Keep exactly one active.
+    this.rotateBy = function (degrees) {
+        // --- animated ---
+        // var current = this.osd.viewport.getRotation();
+        // this._animateRotation(current, current + degrees, 300);
+
+        // --- instant (snap) ---
+        var current = this.osd.viewport.getRotation();
+        this.osd.viewport.setRotation(current + degrees);
+        this.osd.viewport.applyConstraints();
+    }
+
+    // Reset the OSD viewport rotation back to 0 degrees. Same two-mode pattern
+    // as rotateBy: keep exactly one body active.
+    this.resetRotation = function () {
+        // --- animated (shortest path back to 0; e.g. 270° animates +90° through
+        // 360 instead of going the long way back) ---
+        // var current = this.osd.viewport.getRotation();
+        // var target = current > 180 ? 360 : 0;
+        // this._animateRotation(current, target, 300);
+
+        // --- instant (snap) ---
+        this.osd.viewport.setRotation(0);
+        this.osd.viewport.applyConstraints();
+    }
+
+    // requestAnimationFrame handle for the in-progress rotation tween, if any.
+    this._rotationAnimationFrame = null;
+
+    // Smoothly tween the OSD viewport rotation from `from` to `to` over
+    // `duration` ms using an ease-out cubic. OSD 2.4.2 has no built-in viewport
+    // rotation animation, so we drive it manually.
+    this._animateRotation = function (from, to, duration) {
+        var _self = this;
+
+        // cancel any in-progress tween so back-to-back clicks don't fight
+        if (this._rotationAnimationFrame) {
+            cancelAnimationFrame(this._rotationAnimationFrame);
+            this._rotationAnimationFrame = null;
+        }
+
+        var start = performance.now();
+        var ease = function (t) { return 1 - Math.pow(1 - t, 3); };
+
+        var step = function (now) {
+            var t = Math.min((now - start) / duration, 1);
+            var angle = from + (to - from) * ease(t);
+            // setRotation internally normalizes via positiveModulo, so passing
+            // values outside [0, 360) (e.g. -45 or 370) still produces smooth
+            // visual rotation across the 0/360 boundary.
+            _self.osd.viewport.setRotation(angle);
+            if (t < 1) {
+                _self._rotationAnimationFrame = requestAnimationFrame(step);
+            } else {
+                _self._rotationAnimationFrame = null;
+                _self.osd.viewport.applyConstraints();
+            }
+        };
+
+        this._rotationAnimationFrame = requestAnimationFrame(step);
     }
 
     /**

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -1682,29 +1682,27 @@ function Viewer(parent, config) {
                 "rotate(" + rotation + "deg) " +
                 "translate(" + (-scrTL.x) + "px, " + (-scrTL.y) + "px)";
 
-            // Counter-rotate each text annotation so the text stays upright
-            // regardless of viewport rotation. Combined with the parent SVG's
-            // rotate(R) the net visual rotation is 0, while the anchor stays
-            // glued to the rotated image coordinate.
+            // Counter-rotate the EDITABLE text wrappers (.text-foreign-object-div)
+            // so the user can always type left-to-right regardless of viewport
+            // rotation. The pivot is at the text content's top-left (offset
+            // inward from the wrapper's top-left by padding + border) so that
+            // on finalize the visible position doesn't jump.
             //
-            // The rotation pivot has to point at the text-content's top-left
-            // in both states:
-            //   - editing: wrapper is .text-foreign-object-div, whose top-left
-            //     is OUTSIDE the text content by (padding + border). Pivot
-            //     must be at that inward offset.
-            //   - finalized: wrapper is a bare <p>, whose top-left IS the
-            //     text content. Pivot is at 0 0.
-            // Aligning the pivot keeps the text from jumping on finalize.
+            // Finalized text (<p>) is intentionally NOT touched here.
+            // text.js#transform() bakes a `rotate(-R0)` into the <p> at the
+            // moment of finalize, where R0 is the viewport rotation at that
+            // moment. Combined with the parent SVG's current rotation R, the
+            // visible rotation of the text is (R - R0) — so it's "stickied"
+            // to the image's orientation at creation time and rotates with
+            // subsequent viewport changes like any other shape annotation.
             var textForeignObjects = svgs[i].querySelectorAll(".text-foreign-object");
             for (var j = 0; j < textForeignObjects.length; j++) {
                 var inner = textForeignObjects[j].firstElementChild;
                 if (!inner || !inner.style) continue;
-                var originX = 0, originY = 0;
-                if (inner.classList && inner.classList.contains("text-foreign-object-div")) {
-                    var cs = getComputedStyle(inner);
-                    originX = (parseFloat(cs.paddingLeft) || 0) + (parseFloat(cs.borderLeftWidth) || 0);
-                    originY = (parseFloat(cs.paddingTop) || 0) + (parseFloat(cs.borderTopWidth) || 0);
-                }
+                if (!inner.classList || !inner.classList.contains("text-foreign-object-div")) continue;
+                var cs = getComputedStyle(inner);
+                var originX = (parseFloat(cs.paddingLeft) || 0) + (parseFloat(cs.borderLeftWidth) || 0);
+                var originY = (parseFloat(cs.paddingTop) || 0) + (parseFloat(cs.borderTopWidth) || 0);
                 inner.style.transformOrigin = originX + "px " + originY + "px";
                 inner.style.transform = "rotate(" + (-rotation) + "deg)";
             }

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -859,6 +859,13 @@ function Viewer(parent, config) {
         // Only execute it once when Openseadragon is done loading
         if (!_self.isInitLoad) {
 
+            // apply the saved default rotation (if any). done before importing
+            // annotations so the 'rotate' event positions the overlay correctly.
+            if (_self.parameters.imageConfig && typeof _self.parameters.imageConfig.rotate === 'number') {
+                _self.osd.viewport.setRotation(_self.parameters.imageConfig.rotate);
+                _self.osd.viewport.applyConstraints();
+            }
+
             // Check if need to pan to a specific location (if x, y, z are not null)
             if (_self.parameters.x && _self.parameters.y && _self.parameters.z) {
                 _self.panTo(_self.parameters.x, _self.parameters.y, _self.parameters.x, _self.parameters.z);
@@ -1514,71 +1521,26 @@ function Viewer(parent, config) {
         this.osd.viewport.applyConstraints();
     }
 
-    // Rotate the OSD viewport by the given delta in degrees. Positive values are
-    // clockwise; negative values counterclockwise. Note: this only rotates the
-    // scene. SVG annotation overlays don't follow yet (TODO).
-    //
-    // Two implementations below: animated (smooth tween) and instant (snap).
-    // Toggle by commenting/uncommenting the bodies. Keep exactly one active.
+    /**
+     * Rotate the OSD viewport by the given delta in degrees. Positive values are
+     * clockwise, negative counterclockwise. The annotation overlay follows via
+     * the 'rotate' event handler (resizeSVG).
+     * @param {number} degrees the delta to rotate by
+     */
     this.rotateBy = function (degrees) {
-        // --- animated ---
-        // var current = this.osd.viewport.getRotation();
-        // this._animateRotation(current, current + degrees, 300);
-
-        // --- instant (snap) ---
         var current = this.osd.viewport.getRotation();
         this.osd.viewport.setRotation(current + degrees);
         this.osd.viewport.applyConstraints();
     }
 
-    // Reset the OSD viewport rotation back to 0 degrees. Same two-mode pattern
-    // as rotateBy: keep exactly one body active.
-    this.resetRotation = function () {
-        // --- animated (shortest path back to 0; e.g. 270° animates +90° through
-        // 360 instead of going the long way back) ---
-        // var current = this.osd.viewport.getRotation();
-        // var target = current > 180 ? 360 : 0;
-        // this._animateRotation(current, target, 300);
-
-        // --- instant (snap) ---
-        this.osd.viewport.setRotation(0);
+    /**
+     * Reset the OSD viewport rotation to the given absolute degrees (the saved
+     * default; defaults to 0 when omitted).
+     * @param {number} [degrees=0] the absolute rotation to snap to
+     */
+    this.resetRotation = function (degrees) {
+        this.osd.viewport.setRotation(degrees || 0);
         this.osd.viewport.applyConstraints();
-    }
-
-    // requestAnimationFrame handle for the in-progress rotation tween, if any.
-    this._rotationAnimationFrame = null;
-
-    // Smoothly tween the OSD viewport rotation from `from` to `to` over
-    // `duration` ms using an ease-out cubic. OSD 2.4.2 has no built-in viewport
-    // rotation animation, so we drive it manually.
-    this._animateRotation = function (from, to, duration) {
-        var _self = this;
-
-        // cancel any in-progress tween so back-to-back clicks don't fight
-        if (this._rotationAnimationFrame) {
-            cancelAnimationFrame(this._rotationAnimationFrame);
-            this._rotationAnimationFrame = null;
-        }
-
-        var start = performance.now();
-        var ease = function (t) { return 1 - Math.pow(1 - t, 3); };
-
-        var step = function (now) {
-            var t = Math.min((now - start) / duration, 1);
-            var angle = from + (to - from) * ease(t);
-            // setRotation internally normalizes via positiveModulo, so passing
-            // values outside [0, 360) (e.g. -45 or 370) still produces smooth
-            // visual rotation across the 0/360 boundary.
-            _self.osd.viewport.setRotation(angle);
-            if (t < 1) {
-                _self._rotationAnimationFrame = requestAnimationFrame(step);
-            } else {
-                _self._rotationAnimationFrame = null;
-                _self.osd.viewport.applyConstraints();
-            }
-        };
-
-        this._rotationAnimationFrame = requestAnimationFrame(step);
     }
 
     /**

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -736,6 +736,7 @@ function Viewer(parent, config) {
         var pixelRatio = self._utils.queryForRetina(newCanvas);
         // Snapshot rotation once so all SVGs are drawn against a consistent value.
         var rotation = _self.osd.viewport.getRotation();
+        // getRotation() is in degrees; canvas rotate() (below) takes radians.
         var rotationRad = rotation * Math.PI / 180;
         // External CSS isn't applied during standalone rasterization, so inline
         // these resolved styles onto each <p> before serializing.
@@ -779,7 +780,13 @@ function Viewer(parent, config) {
                     dims.push(Number(svgAttr) * pixelRatio);
                 });
 
-                // Rotate around the SVG's screen-space top-left (matches the DOM transform that resizeSVG sets).
+                /*
+                 * In the live DOM each annotation is rotated around its top-left corner.
+                 * Reproduce that here so the rasterized output matches. ctx.rotate() always
+                 * rotates around the canvas origin (0,0), so to rotate around the SVG's
+                 * top-left instead we move that corner to the origin (translate by dims),
+                 * rotate, then move it back. restore() (below) undoes all three.
+                 */
                 if (rotation !== 0) {
                     newCtx.save();
                     newCtx.translate(dims[0], dims[1]);
@@ -1138,8 +1145,6 @@ function Viewer(parent, config) {
                 tileSource: tileSource,
                 compositeOperation: 'lighter',
                 opacity: (channel["isDisplay"] ? 1 : 0),
-                // TODO: rotation - per-image rotation (clockwise, around top-left)
-                degrees: 0,
             });
         }
 
@@ -1227,8 +1232,6 @@ function Viewer(parent, config) {
                 tileSource: tileSource,
                 compositeOperation: 'lighter',
                 opacity: (channel["isDisplay"] ? 1 : 0),
-                // TODO: rotation - per-image rotation (clockwise, around top-left)
-                degrees: 0,
             });
         }
 


### PR DESCRIPTION
This PR adds the APIs that https://github.com/informatics-isi-edu/chaise/pull/2768 uses to allow users to rotate images. The changes are,

- Added `rotate` / `resetRotation` postMessage handlers backed by `Viewer.rotateBy(degrees)` and `Viewer.resetRotation(degrees)`. `resetRotation` takes an optional target so the client can discard back to the saved rotation instead of always 0.
- Apply the default rotation passed in the image config (`imageConfig.rotate`) when the image loads.
- `resizeSVG` rotates the annotation overlays with the viewport via a CSS transform, sizing each SVG from three projected corners so width/height stay correct at 90°/270°. It also subscribes to OSD's `rotate` event (which, unlike `animation`, fires on `setRotation`).
- Text annotations: the editable input is counter-rotated so typing stays upright, while finalized text is stuck to the image's orientation at creation time and rotates with the viewport like any other shape. This survives save and reload, which required `styleStringToObject` to stop stripping whitespace inside values (it was corrupting `transform-origin: 0px 0px`).
- Screenshots reproduce the rotated view: each annotation SVG is rotated via the canvas and its text styles are inlined so the standalone render matches what's on screen.
- Thumbnails in `z-plane-list.js` are rotated with a CSS transform on the `<img>` instead of through the IIIF URL, so the same un-rotated image serves every rotation (no refetch on rotate). All thumbnails track the current viewport rotation and refresh on the `rotate` event.
